### PR TITLE
fix(news): prevent duplicate null-key crash on en locale news list

### DIFF
--- a/components/featured-updates-section.tsx
+++ b/components/featured-updates-section.tsx
@@ -23,7 +23,7 @@ export async function FeaturedUpdatesSection({ locale, dict }: FeaturedUpdatesSe
         {latestPosts.length > 0 ? (
           <div className="grid gap-6 md:grid-cols-3">
             {latestPosts.map((post) => (
-              <NewsCard key={post.slug} post={post} locale={locale} dict={dict} />
+              <NewsCard key={post.id} post={post} locale={locale} dict={dict} />
             ))}
           </div>
         ) : (

--- a/components/news-list-client.tsx
+++ b/components/news-list-client.tsx
@@ -183,7 +183,7 @@ export function NewsListClient({
         <>
           <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
             {visible.map((post) => (
-              <NewsCard key={post.slug} post={post} locale={locale} dict={dict} />
+              <NewsCard key={post.id} post={post} locale={locale} dict={dict} />
             ))}
           </div>
 

--- a/lib/news-data.ts
+++ b/lib/news-data.ts
@@ -26,17 +26,19 @@ export async function getNewsPosts(locale: string): Promise<NewsPost[]> {
   );
   if (!res.ok) return [];
   const json = await res.json();
-  return json.data.map((item: any) => ({
-    id: item.id,
-    slug: item.slug,
-    title: item.title ?? "",
-    summary: item.summary ?? "",
-    body: item.body ?? [],
-    date: item.publishedAt ?? item.createdAt ?? item.date ?? "",
-    tags: (item.tags ?? []).map((t: any) => t.name.toLowerCase() as NewsTag),
-    author: item.author ?? undefined,
-    readTimeMin: item.read_time_min ?? 1,
-  }));
+  return json.data
+    .filter((item: any) => item.slug) // skip entries with no slug (e.g. missing localization)
+    .map((item: any) => ({
+      id: item.id,
+      slug: item.slug,
+      title: item.title ?? "",
+      summary: item.summary ?? "",
+      body: item.body ?? [],
+      date: item.publishedAt ?? item.createdAt ?? item.date ?? "",
+      tags: (item.tags ?? []).map((t: any) => t.name.toLowerCase() as NewsTag),
+      author: item.author ?? undefined,
+      readTimeMin: item.read_time_min ?? 1,
+    }));
 }
 
 export async function getNewsPostBySlug(slug: string, locale: string): Promise<NewsPost | undefined> {


### PR DESCRIPTION
NewsCard lists were keyed on post.slug, which is null for en-locale posts whose non-localized uid slug never synced from the CMS. Multiple null slugs produced duplicate React keys (and /news/null links). Key on the stable post.id instead, and drop slug-less posts in getNewsPosts so broken cards never render.