### PR TITLE
feat(cache): ISR-cache Strapi fetches + working revalidate webhook (#53)

### DIFF
--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,11 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { revalidatePath } from 'next/cache';
 
+// Strapi webhook target. Configure Strapi to POST here (with the shared secret in
+// the `x-webhook-secret` header) on any content publish/update/delete. We
+// revalidate the root layout so every page rebuilds with fresh CMS data on the
+// next visit — keeping the site current without waiting for the fetch revalidate
+// TTL (lib/*-data.ts fetches cache for 1h as a fallback).
 export async function POST(req: NextRequest) {
   const secret = req.headers.get('x-webhook-secret');
-  if (secret !== process.env.WEBHOOK_SECRET) {
+  if (!process.env.WEBHOOK_SECRET || secret !== process.env.WEBHOOK_SECRET) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+
   revalidatePath('/', 'layout');
-  return NextResponse.json({ revalidated: true });
+
+  return NextResponse.json({ revalidated: true, now: Date.now() });
 }

--- a/lib/about-data.ts
+++ b/lib/about-data.ts
@@ -33,7 +33,7 @@ function mapBoardMember(item: any): BoardMember {
 }
 
 export async function getBoardMembers(locale: string): Promise<BoardMember[]> {
-  const first = await fetch(boardMembersUrl(locale, 1), { next: { revalidate: 0 } });
+  const first = await fetch(boardMembersUrl(locale, 1), { next: { revalidate: 3600 } });
   if (!first.ok) return [];
 
   const json = await first.json();
@@ -43,7 +43,7 @@ export async function getBoardMembers(locale: string): Promise<BoardMember[]> {
   if (pageCount > 1) {
     const rest = await Promise.all(
       Array.from({ length: pageCount - 1 }, (_, i) =>
-        fetch(boardMembersUrl(locale, i + 2), { next: { revalidate: 0 } }).then((res) =>
+        fetch(boardMembersUrl(locale, i + 2), { next: { revalidate: 3600 } }).then((res) =>
           res.ok ? res.json().then((j) => j.data as any[]) : []
         )
       )
@@ -64,7 +64,7 @@ export interface Milestone {
 export async function getMilestones(locale: string): Promise<Milestone[]> {
   const res = await fetch(
     `${BASE_URL}/api/milestones?sort=year:asc&locale=${locale}`,
-    { next: { revalidate: 0 } }
+    { next: { revalidate: 3600 } }
   );
   if (!res.ok) return [];
   const json = await res.json();
@@ -86,7 +86,7 @@ export async function getMissionVisionCards(locale: string): Promise<AboutCard[]
   try {
     const res = await fetch(
       `${BASE_URL}/api/mission-vision?populate=cards&locale=${locale}`,
-      { next: { revalidate: 0 } }
+      { next: { revalidate: 3600 } }
     );
     if (!res.ok) return [];
     const json = await res.json();
@@ -112,7 +112,7 @@ export async function getObjectives(locale: string): Promise<ObjectiveItem[]> {
   try {
     const res = await fetch(
       `${BASE_URL}/api/objective?populate=items&locale=${locale}`,
-      { next: { revalidate: 0 } }
+      { next: { revalidate: 3600 } }
     );
     if (!res.ok) return [];
     const json = await res.json();

--- a/lib/apply-data.ts
+++ b/lib/apply-data.ts
@@ -8,7 +8,7 @@ const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").re
 export async function getApplyLink(locale: string): Promise<string | null> {
   try {
     const res = await fetch(`${BASE_URL}/api/membership-apply?locale=${locale}`, {
-      next: { revalidate: 0 },
+      next: { revalidate: 3600 },
     });
     if (!res.ok) return null;
     const json = await res.json();

--- a/lib/archive-data.ts
+++ b/lib/archive-data.ts
@@ -17,7 +17,7 @@ export interface ArchiveGroups {
 
 async function fetchAPI(endpoint: string) {
   try {
-    const res = await fetch(`${BASE_URL}${endpoint}`, { cache: "no-store" });
+    const res = await fetch(`${BASE_URL}${endpoint}`, { next: { revalidate: 3600 } });
     if (!res.ok) return null;
     const json = await res.json();
     return json?.data || [];

--- a/lib/conferences-data.ts
+++ b/lib/conferences-data.ts
@@ -10,7 +10,7 @@ export interface Conference {
 export async function getConferences(locale: string): Promise<Conference[]> {
   const res = await fetch(
     `${BASE_URL}/api/conferences?sort=order:asc&locale=${locale}`,
-    { next: { revalidate: 0 } }
+    { next: { revalidate: 3600 } }
   );
   if (!res.ok) return [];
   const json = await res.json();

--- a/lib/contact-data.ts
+++ b/lib/contact-data.ts
@@ -10,7 +10,7 @@ export interface ContactInfo {
 export async function getContact(locale: string): Promise<ContactInfo | null> {
   try {
     const res = await fetch(`${BASE_URL}/api/contact?locale=${locale}`, {
-      next: { revalidate: 0 },
+      next: { revalidate: 3600 },
     });
     if (!res.ok) return null;
     const json = await res.json();

--- a/lib/documents-data.ts
+++ b/lib/documents-data.ts
@@ -11,7 +11,7 @@ const BASE_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").re
 
 async function fetchAPI(endpoint: string) {
   try {
-    const res = await fetch(`${BASE_URL}${endpoint}`, { cache: "no-store" });
+    const res = await fetch(`${BASE_URL}${endpoint}`, { next: { revalidate: 3600 } });
     if (!res.ok) return null;
     const json = await res.json();
     return json?.data || [];

--- a/lib/events-data.ts
+++ b/lib/events-data.ts
@@ -39,7 +39,7 @@ export interface ECTIEvent {
 export async function fetchEventBySlug(slug: string, locale: string) {
   const res = await fetch(
     `${API_URL}?populate=*&filters[slug][$eq]=${slug}&locale=${locale}`,
-    { cache: "no-store" }
+    { next: { revalidate: 3600 } }
   );
 
   const json = await res.json();
@@ -79,7 +79,7 @@ export async function fetchEventBySlug(slug: string, locale: string) {
 export async function fetchEventsFromAPI(locale: string): Promise<ECTIEvent[]> {
   const res = await fetch(
     `${API_URL}?populate=*&sort=event_start_date:desc&locale=${locale}`,
-    { cache: "no-store" }
+    { next: { revalidate: 3600 } }
   );
 
   const json = await res.json();
@@ -150,7 +150,7 @@ export async function getFeaturedEvents(
 ): Promise<FeaturedEvent[]> {
   const res = await fetch(
     `${API_URL}?populate=*&sort=event_start_date:desc&pagination[limit]=${limit}&locale=${locale}`,
-    { cache: "no-store" }
+    { next: { revalidate: 3600 } }
   );
 
   if (!res.ok) return [];

--- a/lib/membership-data.ts
+++ b/lib/membership-data.ts
@@ -59,7 +59,7 @@ export interface MembershipDocument {
 async function fetchAPI(endpoint: string) {
   try {
     const res = await fetch(`${BASE_URL}${endpoint}`, {
-      cache: "no-store",
+      next: { revalidate: 3600 },
     });
     if (!res.ok) {
         return null;

--- a/lib/news-data.ts
+++ b/lib/news-data.ts
@@ -33,7 +33,7 @@ export interface NewsPost {
 export async function getNewsPosts(locale: string): Promise<NewsPost[]> {
   const res = await fetch(
     `${BASE_URL}/api/news-posts?populate=tags&sort=publishedAt:desc&locale=${locale}`,
-    { next: { revalidate: 0 } }
+    { next: { revalidate: 3600 } }
   );
   if (!res.ok) return [];
   const json = await res.json();
@@ -55,7 +55,7 @@ export async function getNewsPosts(locale: string): Promise<NewsPost[]> {
 export async function getNewsPostBySlug(slug: string, locale: string): Promise<NewsPost | undefined> {
   const res = await fetch(
     `${BASE_URL}/api/news-posts?filters[slug][$eq]=${slug}&populate=tags&locale=${locale}`,
-    { next: { revalidate: 0 } }
+    { next: { revalidate: 3600 } }
   );
   if (!res.ok) return undefined;
   const json = await res.json();

--- a/lib/publications-data.ts
+++ b/lib/publications-data.ts
@@ -10,7 +10,7 @@ export interface Journal {
 export async function getJournals(locale: string): Promise<Journal[]> {
   const res = await fetch(
     `${BASE_URL}/api/journals?sort=order:asc&locale=${locale}`,
-    { next: { revalidate: 0 } }
+    { next: { revalidate: 3600 } }
   );
   if (!res.ok) return [];
   const json = await res.json();

--- a/lib/resources-data.ts
+++ b/lib/resources-data.ts
@@ -14,7 +14,7 @@ export interface ResourceLink {
 async function fetchAPI(endpoint: string) {
   try {
     const res = await fetch(`${BASE_URL}${endpoint}`, {
-      cache: "no-store",
+      next: { revalidate: 3600 },
     });
     if (!res.ok) {
       return null;

--- a/lib/social-data.ts
+++ b/lib/social-data.ts
@@ -23,7 +23,7 @@ function clean(url: unknown): string | null {
 export async function getSocialLinks(locale: string): Promise<SocialLinks> {
   try {
     const res = await fetch(`${BASE_URL}/api/social-link?locale=${locale}`, {
-      next: { revalidate: 0 },
+      next: { revalidate: 3600 },
     });
     if (!res.ok) return EMPTY;
     const json = await res.json();


### PR DESCRIPTION
Closes #53

## ปัญหา
ทุก fetch ใน `lib/*-data.ts` ตั้ง `revalidate:0` / `no-store` → คนเข้าเว็บ 1 ครั้ง
ยิง Strapi สดทุกครั้ง = ช้า (ยิ่ง free-tier cold start) + เผาโควต้า API

## การแก้
1. เปลี่ยน fetch ทุกจุด (12 ไฟล์) → `revalidate: 3600` (cache 1 ชม.)
   เว็บเสิร์ฟจาก cache, ยิง Strapi ~1 ครั้ง/ชม./หน้า แทนทุก view
2. ทำ `/api/revalidate` (มี route อยู่แต่ไร้ประโยชน์เพราะ fetch ไม่ cache) ให้ทำงานจริง:
   POST + secret ถูก → `revalidatePath('/', 'layout')` → refresh ทุกหน้าทันที
   → content ที่แก้ใน CMS ขึ้นเว็บในไม่กี่วิ ไม่ต้องรอครบ TTL

## หมายเหตุ Next 16
`revalidateTag` เปลี่ยน signature (ต้องมี arg profile) เข้ากับ fetch tags เดิมไม่ได้
เนื่องจากใช้ invalidate รวมทั้งเว็บอยู่แล้ว จึงใช้ `revalidatePath('/', 'layout')` ผลเดียวกัน

## ทดสอบ
- `tsc` ผ่าน, ทุกหน้า render 200
- Route: no/wrong secret → 401, correct secret → 200 `{revalidated:true}`

## ต้องตั้งค่าหลัง merge (ไม่อยู่ในโค้ด)
- Vercel env `WEBHOOK_SECRET` = <สุ่มยาวๆ> (Production) แล้ว redeploy
- Strapi webhook → POST `https://<โดเมน>/api/revalidate`, header `x-webhook-secret` = ค่าเดียวกัน,
  events: entry publish/update/delete