### PR TITLE
fix(news): put article body on a white card for readability

### DIFF
--- a/app/[locale]/(site)/news/[slug]/page.tsx
+++ b/app/[locale]/(site)/news/[slug]/page.tsx
@@ -91,7 +91,7 @@ export default async function NewsDetailPage({ params }: PageProps) {
         </Link>
 
         <div className="mt-6 grid gap-8 lg:grid-cols-3">
-          <article className="lg:col-span-2">
+          <article className="rounded-xl border border-border bg-card p-6 shadow-sm lg:col-span-2 lg:p-8">
             {/* Cover image is the card preview only; images inside the article come from the body. */}
             <div className="mb-8 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-muted-foreground">
               <span className="flex items-center gap-1.5">


### PR DESCRIPTION
## ปัญหา
หน้าอ่านข่าว (`news/[slug]`) เนื้อบทความวางอยู่บน "พื้นหลังสีเทาอ่อน" ของหน้าโดยตรง
ทำให้ดูทึบ อ่านไม่คม โดยเฉพาะเมื่อเทียบกับการ์ด sidebar ที่เป็นสีขาว

## แก้ยังไง
ห่อ `<article>` ด้วยพื้นการ์ดสีขาว (`bg-card`) + ขอบ + เงาจางๆ + padding
→ คอลัมน์อ่านข่าวอยู่บนพื้นขาวสนิท อ่านง่ายขึ้น และเข้าชุดกับการ์ด sidebar

## ขอบเขต
- แก้เฉพาะหน้าอ่านข่าว ไม่กระทบหน้าอื่น
- เปลี่ยน className บรรทัดเดียว

Closes #68