### PR TITLE
fix(home): shrink featured event card and match events-page detail button

### DIFF
--- a/components/featured-event-section.tsx
+++ b/components/featured-event-section.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { MapPin, CalendarDays, FileText, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -13,34 +12,32 @@ interface FeaturedEventSectionProps {
 
 function FeaturedEventCard({
   event,
-  eventsHref,
   dict,
 }: {
   event: FeaturedEvent;
-  eventsHref: string;
   dict: Dictionary;
 }) {
   return (
     <div className="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
       <div className="flex flex-col lg:flex-row">
         {/* Left: visual banner */}
-        <div className="relative flex flex-col items-center justify-center gap-4 bg-primary px-8 py-12 text-center text-primary-foreground lg:w-2/5 lg:py-16">
+        <div className="relative flex flex-col items-center justify-center gap-3 bg-primary px-6 py-8 text-center text-primary-foreground lg:w-2/5 lg:py-10">
           <div className="absolute inset-0 opacity-10">
             <div className="absolute -right-16 -top-16 h-64 w-64 rounded-full bg-primary-foreground/20" />
             <div className="absolute -bottom-20 -left-20 h-56 w-56 rounded-full bg-primary-foreground/15" />
           </div>
-          <div className="relative flex flex-col items-center gap-3">
-            <span className="text-5xl font-bold md:text-6xl">
+          <div className="relative flex flex-col items-center gap-2">
+            <span className="text-3xl font-bold md:text-4xl">
               {event.title}
             </span>
             {event.description && (
-              <p className="text-base text-primary-foreground/80">
+              <p className="text-sm text-primary-foreground/80">
                 {event.description}
               </p>
             )}
 
             {event.location && (
-              <div className="mt-2 flex items-center gap-2 text-sm text-primary-foreground/70">
+              <div className="mt-1 flex items-center gap-2 text-sm text-primary-foreground/70">
                 <MapPin className="h-4 w-4" aria-hidden="true" />
                 <span>{event.location}</span>
               </div>
@@ -49,11 +46,11 @@ function FeaturedEventCard({
         </div>
 
         {/* Right: details */}
-        <div className="flex flex-1 flex-col justify-center gap-6 p-8 lg:p-12">
+        <div className="flex flex-1 flex-col justify-center gap-4 p-6 lg:p-8">
           {event.dateLabel && (
             <div className="flex items-center gap-3">
               <CalendarDays className="h-5 w-5 text-primary" aria-hidden="true" />
-              <span className="text-lg font-semibold text-foreground">
+              <span className="text-base font-semibold text-foreground">
                 {event.dateLabel}
               </span>
             </div>
@@ -76,16 +73,26 @@ function FeaturedEventCard({
             </>
           )}
 
-          <Separator />
+          {/* External event link — like the events page, the button is hidden
+              entirely when the event has no link set. */}
+          {event.registerUrl && (
+            <>
+              <Separator />
 
-          <div className="flex flex-wrap gap-3">
-            <Link href={eventsHref}>
-              <Button className="gap-2 bg-accent text-accent-foreground hover:bg-accent/90">
-                {dict.events.btnDetails}
-                <ArrowRight className="h-4 w-4" aria-hidden="true" />
-              </Button>
-            </Link>
-          </div>
+              <div className="flex flex-wrap gap-3">
+                <a
+                  href={event.registerUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Button className="gap-2 bg-accent text-accent-foreground hover:bg-accent/90">
+                    {dict.events.btnDetails}
+                    <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </a>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>
@@ -98,25 +105,18 @@ export async function FeaturedEventSection({ locale, dict }: FeaturedEventSectio
   // No activities to feature (or API unreachable) — hide the section entirely.
   if (events.length === 0) return null;
 
-  const eventsHref = `/${locale}/events`;
-
   return (
-    <section className="bg-background py-16 lg:py-24">
+    <section className="bg-background py-12 lg:py-16">
       <div className="mx-auto max-w-7xl px-4 lg:px-8">
-        <div className="mb-10 text-center">
+        <div className="mb-8 text-center">
           <h2 className="text-balance text-3xl font-bold text-foreground md:text-4xl">
             {dict.home.sectionFeaturedEvent}
           </h2>
         </div>
 
-        <div className="flex flex-col gap-8">
+        <div className="flex flex-col gap-6">
           {events.map((event) => (
-            <FeaturedEventCard
-              key={event.slug}
-              event={event}
-              eventsHref={eventsHref}
-              dict={dict}
-            />
+            <FeaturedEventCard key={event.slug} event={event} dict={dict} />
           ))}
         </div>
       </div>


### PR DESCRIPTION
## สิ่งที่แก้
1. **ย่อขนาดกล่อง/ข้อความ** ให้กระชับ ไม่เด่นเกินสัดส่วนหน้า
   - ชื่องาน 5xl/6xl → 3xl/4xl
   - padding แบนเนอร์ py-12/16 → py-8/10, px-8 → px-6
   - padding รายละเอียด p-8/12 → p-6/8 + gap เล็กลง
   - วันที่ text-lg → text-base, ระยะ section py-16/24 → py-12/16
2. **ปุ่ม "รายละเอียด" ทำงานเหมือนหน้ากิจกรรม**
   - ลิงก์ไป**เว็บนอกของงาน** (`registerUrl`) เปิดแท็บใหม่
   - **ถ้าไม่มีลิงก์ → ซ่อนปุ่ม** (รวมเส้นคั่น)

## ขอบเขต
- แก้เฉพาะ `components/featured-event-section.tsx`
- ไม่แตะ logic การดึงข้อมูล

Closes #67