### PR TITLE
feat(news): keep the article title visible while reading

### DIFF
--- a/app/[locale]/(site)/news/[slug]/page.tsx
+++ b/app/[locale]/(site)/news/[slug]/page.tsx
@@ -23,6 +23,7 @@ import {
   getRelatedPosts,
 } from "@/lib/news-data";
 import { NewsShareButton } from "@/components/news-share-button";
+import { NewsStickyTitle } from "@/components/news-sticky-title";
 import { getTagLabel, getTagStyle } from "@/components/news-card";
 
 interface PageProps {
@@ -80,6 +81,8 @@ export default async function NewsDetailPage({ params }: PageProps) {
           { label: title.length > 40 ? title.slice(0, 40) + "..." : title },
         ]}
       />
+
+      <NewsStickyTitle title={title} />
 
       <div className="mx-auto max-w-7xl px-4 py-10 lg:px-8 lg:py-14">
         <Link

--- a/components/news-sticky-title.tsx
+++ b/components/news-sticky-title.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Slim bar that slides in just below the sticky nav once the reader scrolls
+ * past the article hero, so they always know which article they're reading.
+ *
+ * A zero-height sentinel sits in normal flow right below the hero; an
+ * IntersectionObserver (with the nav height as top rootMargin) flips the bar
+ * on exactly when that point scrolls under the nav — robust to any hero
+ * height. The bar itself is fixed, so it takes no layout space and leaves no
+ * gap when hidden.
+ */
+export function NewsStickyTitle({ title }: { title: string }) {
+  const sentinel = useRef<HTMLDivElement>(null);
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    const el = sentinel.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      ([entry]) => setShow(!entry.isIntersecting),
+      // Shrink the root's top by the sticky nav height (~64px = top-16).
+      { rootMargin: "-64px 0px 0px 0px", threshold: 0 }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  return (
+    <>
+      <div ref={sentinel} aria-hidden className="h-0" />
+      <div
+        aria-hidden={!show}
+        className={`fixed inset-x-0 top-16 z-40 border-b border-border bg-card/95 backdrop-blur transition-all duration-200 supports-[backdrop-filter]:bg-card/80 ${
+          show
+            ? "translate-y-0 opacity-100"
+            : "pointer-events-none -translate-y-2 opacity-0"
+        }`}
+      >
+        <div className="mx-auto max-w-7xl px-4 py-3 lg:px-8">
+          <p className="truncate text-lg font-semibold text-foreground">
+            {title}
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## สิ่งที่แก้
เพิ่ม **แถบชื่อเรื่องบางๆ สไลด์เข้ามาค้างใต้ nav** เมื่อเลื่อนพ้น hero
→ ผู้อ่านเห็นตลอดว่ากำลังอ่านข่าวอะไร

## รายละเอียด
- component ใหม่ `components/news-sticky-title.tsx` (client)
- **IntersectionObserver + sentinel** → แถบโผล่ตรงจังหวะ hero พ้น nav พอดี ไม่ว่าชื่อยาวแค่ไหน
- แถบ `fixed top-16 z-40` — ค้างใต้ nav พอดี ไม่กินพื้นที่ layout ไม่มีช่องว่างตอนซ่อน
- ตัวอักษร `text-lg` ใหญ่กว่าเนื้อหา content ให้อ่านเป็นหัวเรื่อง, ชื่อยาวตัด `truncate`
- อยู่บนสุดไม่โชว์ (ไม่ซ้ำ hero ที่มีชื่ออยู่แล้ว)

## หมายเหตุ
- nav height สมมติ 64px (`top-16` / rootMargin `-64px`)
- มีไฟล์ใหม่ → `git add components/news-sticky-title.tsx`

Closes #66