### PR TITLE
fix(data): make API fetchers resilient so builds survive Strapi outages

### DIFF
--- a/lib/conferences-data.ts
+++ b/lib/conferences-data.ts
@@ -8,19 +8,24 @@ export interface Conference {
 }
 
 export async function getConferences(locale: string): Promise<Conference[]> {
-  const res = await fetch(
-    `${BASE_URL}/api/conferences?sort=order:asc&locale=${locale}`,
-    { next: { revalidate: 3600 } }
-  );
-  if (!res.ok) return [];
-  const json = await res.json();
-  return json.data.map((item: any) => ({
-    id: item.id,
-    title: item.title ?? "",
-    description: item.description ?? "",
-    years: (item.years ?? "")
-      .split(",")
-      .map((y: string) => y.trim())
-      .filter(Boolean),
-  }));
+  try {
+    const res = await fetch(
+      `${BASE_URL}/api/conferences?sort=order:asc&locale=${locale}`,
+      { next: { revalidate: 3600 } }
+    );
+    if (!res.ok) return [];
+    const json = await res.json();
+    return json.data.map((item: any) => ({
+      id: item.id,
+      title: item.title ?? "",
+      description: item.description ?? "",
+      years: (item.years ?? "")
+        .split(",")
+        .map((y: string) => y.trim())
+        .filter(Boolean),
+    }));
+  } catch (err) {
+    console.warn("getConferences: API unavailable", err);
+    return [];
+  }
 }

--- a/lib/events-data.ts
+++ b/lib/events-data.ts
@@ -37,12 +37,18 @@ export interface ECTIEvent {
 
 //fetch by slug
 export async function fetchEventBySlug(slug: string, locale: string) {
-  const res = await fetch(
-    `${API_URL}?populate=*&filters[slug][$eq]=${slug}&locale=${locale}`,
-    { next: { revalidate: 3600 } }
-  );
-
-  const json = await res.json();
+  let json: any;
+  try {
+    const res = await fetch(
+      `${API_URL}?populate=*&filters[slug][$eq]=${slug}&locale=${locale}`,
+      { next: { revalidate: 3600 } }
+    );
+    if (!res.ok) return null;
+    json = await res.json();
+  } catch (err) {
+    console.warn(`fetchEventBySlug(${slug}): API unavailable, using fallback`, err);
+    return null;
+  }
 
   if (!json || !Array.isArray(json.data) || json.data.length === 0) {
     return null;
@@ -77,12 +83,18 @@ export async function fetchEventBySlug(slug: string, locale: string) {
 // Ordered newest-first here rather than in the client: EventsListClient re-sorts
 // by status with a stable sort, so this date order survives within each status group.
 export async function fetchEventsFromAPI(locale: string): Promise<ECTIEvent[]> {
-  const res = await fetch(
-    `${API_URL}?populate=*&sort=event_start_date:desc&locale=${locale}`,
-    { next: { revalidate: 3600 } }
-  );
-
-  const json = await res.json();
+  let json: any;
+  try {
+    const res = await fetch(
+      `${API_URL}?populate=*&sort=event_start_date:desc&locale=${locale}`,
+      { next: { revalidate: 3600 } }
+    );
+    if (!res.ok) return [];
+    json = await res.json();
+  } catch (err) {
+    console.warn("fetchEventsFromAPI: API unavailable", err);
+    return [];
+  }
 
   if (!json || !Array.isArray(json.data)) {
     console.warn("fetchEventsFromAPI: Invalid data received", json);
@@ -148,14 +160,18 @@ export async function getFeaturedEvents(
   locale: string,
   limit = 5
 ): Promise<FeaturedEvent[]> {
-  const res = await fetch(
-    `${API_URL}?populate=*&sort=event_start_date:desc&pagination[limit]=${limit}&locale=${locale}`,
-    { next: { revalidate: 3600 } }
-  );
-
-  if (!res.ok) return [];
-
-  const json = await res.json();
+  let json: any;
+  try {
+    const res = await fetch(
+      `${API_URL}?populate=*&sort=event_start_date:desc&pagination[limit]=${limit}&locale=${locale}`,
+      { next: { revalidate: 3600 } }
+    );
+    if (!res.ok) return [];
+    json = await res.json();
+  } catch (err) {
+    console.warn("getFeaturedEvents: API unavailable", err);
+    return [];
+  }
   if (!Array.isArray(json?.data)) return [];
 
   return json.data.map((item: any) => ({

--- a/lib/news-data.ts
+++ b/lib/news-data.ts
@@ -70,13 +70,18 @@ function mapNewsPost(item: any): NewsPost {
 // a single language). Fetch one locale's rows; callers merge across locales so a
 // post never disappears / 404s just because it wasn't translated.
 async function fetchNewsRows(locale: string): Promise<any[]> {
-  const res = await fetch(
-    `${BASE_URL}/api/news-posts?populate[tags]=true&populate[cover_image]=true&sort=publishedAt:desc&locale=${locale}`,
-    { next: { revalidate: 3600 } }
-  );
-  if (!res.ok) return [];
-  const json = await res.json();
-  return (json.data ?? []).filter((item: any) => item.slug); // skip entries with no slug
+  try {
+    const res = await fetch(
+      `${BASE_URL}/api/news-posts?populate[tags]=true&populate[cover_image]=true&sort=publishedAt:desc&locale=${locale}`,
+      { next: { revalidate: 3600 } }
+    );
+    if (!res.ok) return [];
+    const json = await res.json();
+    return (json.data ?? []).filter((item: any) => item.slug); // skip entries with no slug
+  } catch (err) {
+    console.warn(`fetchNewsRows(${locale}): API unavailable`, err);
+    return [];
+  }
 }
 
 // Same post shares a documentId across locales (and the slug is non-localized too).
@@ -114,13 +119,17 @@ export async function getNewsPostBySlug(slug: string, locale: string): Promise<N
   // Try the requested locale first, then fall back to any locale that has the post.
   const tryLocales = [locale, ...locales.filter((l) => l !== locale)];
   for (const loc of tryLocales) {
-    const res = await fetch(
-      `${BASE_URL}/api/news-posts?filters[slug][$eq]=${slug}&populate[tags]=true&populate[cover_image]=true&populate[attachments][populate][file]=true&locale=${loc}`,
-      { next: { revalidate: 3600 } }
-    );
-    if (!res.ok) continue;
-    const json = await res.json();
-    if (json.data?.length) return mapNewsPost(json.data[0]);
+    try {
+      const res = await fetch(
+        `${BASE_URL}/api/news-posts?filters[slug][$eq]=${slug}&populate[tags]=true&populate[cover_image]=true&populate[attachments][populate][file]=true&locale=${loc}`,
+        { next: { revalidate: 3600 } }
+      );
+      if (!res.ok) continue;
+      const json = await res.json();
+      if (json.data?.length) return mapNewsPost(json.data[0]);
+    } catch (err) {
+      console.warn(`getNewsPostBySlug(${slug}, ${loc}): API unavailable`, err);
+    }
   }
   return undefined;
 }

--- a/lib/publications-data.ts
+++ b/lib/publications-data.ts
@@ -8,16 +8,21 @@ export interface Journal {
 }
 
 export async function getJournals(locale: string): Promise<Journal[]> {
-  const res = await fetch(
-    `${BASE_URL}/api/journals?sort=order:asc&locale=${locale}`,
-    { next: { revalidate: 3600 } }
-  );
-  if (!res.ok) return [];
-  const json = await res.json();
-  return json.data.map((item: any) => ({
-    id: item.id,
-    title: item.title ?? "",
-    description: item.description ?? "",
-    url: item.url ?? "",
-  }));
+  try {
+    const res = await fetch(
+      `${BASE_URL}/api/journals?sort=order:asc&locale=${locale}`,
+      { next: { revalidate: 3600 } }
+    );
+    if (!res.ok) return [];
+    const json = await res.json();
+    return json.data.map((item: any) => ({
+      id: item.id,
+      title: item.title ?? "",
+      description: item.description ?? "",
+      url: item.url ?? "",
+    }));
+  } catch (err) {
+    console.warn("getJournals: API unavailable", err);
+    return [];
+  }
 }


### PR DESCRIPTION
## ปัญหา
Vercel build ล้มตอน prerender หน้า event — `fetchEventBySlug` เรียก `res.json()` โดยไม่ guard พอ Strapi (Cloud โดน suspend) ตอบเป็น HTML → `JSON.parse` พัง → build ตายทั้งกระบวนการ (fallback static ที่ตั้งใจไว้เลยไม่ทำงาน)

## แก้ยังไง
ครอบ data fetcher ที่ยิงตอน build ด้วย `try/catch` + เพิ่ม `res.ok` ให้ครบ → เจออะไรก็ไม่ throw:
- status error (4xx/5xx) → `res.ok` จับ
- ตอบ 200 แต่ body เป็น HTML → `try/catch` จับ
- host เข้าไม่ถึง / `fetch()` throw → `try/catch` จับ

ทุกเคส return fallback (`null`/`[]`) → build ผ่าน (หน้าใช้ข้อมูล static/ว่างตอน API ล่ม)

## ครอบคลุม (7 ฟังก์ชัน / 4 ไฟล์)
- `events-data.ts`: `fetchEventBySlug`, `fetchEventsFromAPI`, `getFeaturedEvents`
- `news-data.ts`: `fetchNewsRows`, `getNewsPostBySlug`
- `conferences-data.ts`: `getConferences`
- `publications-data.ts`: `getJournals`

## หมายเหตุ
fix นี้ทำให้ build ทน API ล่ม แต่ **ข้อมูลจริงจะกลับมาต่อเมื่อ Strapi กลับมา** (self-host/upgrade)

Closes #74 