### PR TITLE
feat(newsletter): subscribe through Brevo with double opt-in

### DIFF
--- a/app/[locale]/(site)/newsletter/confirmed/page.tsx
+++ b/app/[locale]/(site)/newsletter/confirmed/page.tsx
@@ -1,0 +1,57 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { MailCheck } from "lucide-react";
+import { getDictionary, isValidLocale } from "@/lib/i18n";
+import type { Locale } from "@/lib/i18n";
+import { Button } from "@/components/ui/button";
+
+interface PageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  const { locale } = await params;
+  if (!isValidLocale(locale)) return {};
+  const dict = getDictionary(locale as Locale);
+  return {
+    title: dict.home.newsletterConfirmedTitle,
+    // Nothing here is worth indexing, and the URL is only ever reached from a
+    // link in a confirmation email.
+    robots: { index: false, follow: false },
+  };
+}
+
+/**
+ * Where Brevo sends a subscriber after they click the link in the double opt-in
+ * email (see app/api/subscribe/route.ts).
+ *
+ * A page rather than a toast on the home page: arriving here *is* the result the
+ * person came to see, so it gets the whole screen instead of a corner box that
+ * fades. It also survives a refresh, can be bookmarked, and doesn't depend on
+ * any client-side timing.
+ */
+export default async function NewsletterConfirmedPage({ params }: PageProps) {
+  const { locale } = await params;
+  if (!isValidLocale(locale)) notFound();
+  const dict = getDictionary(locale as Locale);
+
+  return (
+    <div className="mx-auto flex min-h-[60vh] max-w-xl flex-col items-center justify-center gap-6 px-4 py-20 text-center lg:px-8">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <MailCheck className="h-8 w-8" aria-hidden="true" />
+      </div>
+
+      <h1 className="text-balance text-3xl font-bold text-foreground md:text-4xl">
+        {dict.home.newsletterConfirmedTitle}
+      </h1>
+
+      <p className="text-pretty leading-relaxed text-muted-foreground">
+        {dict.home.newsletterConfirmed}
+      </p>
+
+      <Button asChild className="mt-2 h-11">
+        <Link href={`/${locale}`}>{dict.home.newsletterBackHome}</Link>
+      </Button>
+    </div>
+  );
+}

--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,9 +1,59 @@
 import { NextResponse } from "next/server";
 
-const STRAPI_URL = (process.env.NEXT_PUBLIC_API_URL || "http://localhost:1337").replace(/\/+$/, "");
-const STRAPI_API_TOKEN = process.env.STRAPI_API_TOKEN;
+// Newsletter signup → Brevo, using Brevo's double opt-in endpoint: it stores the
+// address as *unconfirmed* and mails a confirmation link, and only a click on
+// that link adds the person to the list. That's what keeps a typo'd or
+// maliciously entered address off the list, and it's the consent record we want
+// under PDPA. Brevo also appends the unsubscribe link to every campaign.
+//
+// The API key stays server-side — this route is the only thing that sees it.
+
+const BREVO_API = "https://api.brevo.com/v3";
+
+const API_KEY = process.env.BREVO_API_KEY;
+const LIST_ID = Number(process.env.BREVO_LIST_ID);
+const DOI_TEMPLATE_ID = Number(process.env.BREVO_DOI_TEMPLATE_ID);
+const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000").replace(/\/+$/, "");
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** Names what's missing so a misconfigured deploy says so instead of 500-ing blind. */
+function missingConfig(): string[] {
+  const missing: string[] = [];
+  if (!API_KEY) missing.push("BREVO_API_KEY");
+  if (!LIST_ID) missing.push("BREVO_LIST_ID");
+  if (!DOI_TEMPLATE_ID) missing.push("BREVO_DOI_TEMPLATE_ID");
+  return missing;
+}
+
+/**
+ * Looks the address up before we ask Brevo to mail anything.
+ *
+ * Necessary because /contacts/doubleOptinConfirmation answers 204 even for an
+ * address that is already a confirmed subscriber — it just mails the
+ * confirmation link again. So the "you're already subscribed" case has to be
+ * detected here; there is no error response to react to.
+ *
+ * Fails open: if the lookup itself breaks, we'd rather send a duplicate
+ * confirmation than turn a working form into an error for everyone.
+ */
+async function findContact(email: string): Promise<{ listIds?: number[]; emailBlacklisted?: boolean } | null> {
+  try {
+    const res = await fetch(`${BREVO_API}/contacts/${encodeURIComponent(email)}`, {
+      headers: { "api-key": API_KEY as string, accept: "application/json" },
+      cache: "no-store",
+    });
+    if (res.status === 404) return null; // never seen this address
+    if (!res.ok) {
+      console.error(`subscribe: contact lookup returned ${res.status}`);
+      return null;
+    }
+    return await res.json();
+  } catch (err) {
+    console.error("subscribe: contact lookup failed", err);
+    return null;
+  }
+}
 
 export async function POST(request: Request) {
   let body: { email?: string; locale?: string };
@@ -20,43 +70,70 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "invalid_email" }, { status: 400 });
   }
 
-  if (!STRAPI_API_TOKEN) {
-    console.error("subscribe: STRAPI_API_TOKEN is not set");
+  const missing = missingConfig();
+  if (missing.length > 0) {
+    console.error(`subscribe: not configured — missing ${missing.join(", ")}`);
     return NextResponse.json({ error: "server_error" }, { status: 500 });
+  }
+
+  // Already a confirmed subscriber? Say so instead of mailing them again.
+  // Someone who unsubscribed (emailBlacklisted) still gets the confirmation
+  // flow — that's them opting back in, and the double opt-in is the record of
+  // that consent. Same for a contact who exists but hasn't confirmed yet:
+  // re-sending the link is the point.
+  const existing = await findContact(email);
+  if (existing && existing.listIds?.includes(LIST_ID) && !existing.emailBlacklisted) {
+    return NextResponse.json({ error: "duplicate" }, { status: 409 });
   }
 
   let res: Response;
   try {
-    res = await fetch(`${STRAPI_URL}/api/subscribers`, {
+    res = await fetch(`${BREVO_API}/contacts/doubleOptinConfirmation`, {
       method: "POST",
       headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${STRAPI_API_TOKEN}`,
+        "api-key": API_KEY as string,
+        "content-type": "application/json",
+        accept: "application/json",
       },
-      body: JSON.stringify({ data: { email, language: locale } }),
+      body: JSON.stringify({
+        email,
+        includeListIds: [LIST_ID],
+        templateId: DOI_TEMPLATE_ID,
+        // Where Brevo sends them after they click confirm — a page that says so
+        // plainly, rather than the home page with a toast they can miss.
+        redirectionUrl: `${SITE_URL}/${locale}/newsletter/confirmed`,
+      }),
       cache: "no-store",
     });
   } catch (err) {
-    console.error("subscribe: cannot reach Strapi", err);
+    console.error("subscribe: cannot reach Brevo", err);
     return NextResponse.json({ error: "server_error" }, { status: 502 });
   }
 
+  // 204 on success — nothing to parse.
   if (res.ok) {
     return NextResponse.json({ ok: true }, { status: 201 });
   }
 
-  // Strapi returns 400 for both validation and unique-constraint violations;
-  // inspect the message to tell a duplicate email apart from other failures.
-  if (res.status === 400) {
-    const data = await res.json().catch(() => null);
-    const msg = JSON.stringify(data ?? "").toLowerCase();
-    if (msg.includes("unique") || msg.includes("already")) {
-      return NextResponse.json({ error: "duplicate" }, { status: 409 });
-    }
+  const data = await res.json().catch(() => null);
+  const code = typeof data?.code === "string" ? data.code : "";
+  const message = JSON.stringify(data ?? "").toLowerCase();
+
+  // Already on the list, or already sent a confirmation they haven't clicked.
+  if (
+    res.status === 400 &&
+    (code === "duplicate_parameter" || message.includes("already") || message.includes("exist"))
+  ) {
+    return NextResponse.json({ error: "duplicate" }, { status: 409 });
+  }
+
+  if (res.status === 400 && (code === "invalid_parameter" || message.includes("email"))) {
     return NextResponse.json({ error: "invalid_email" }, { status: 400 });
   }
 
-  const detail = await res.text().catch(() => "");
-  console.error("subscribe: strapi error", res.status, detail);
+  console.error(
+    `subscribe: Brevo returned ${res.status}: ${JSON.stringify(data)}` +
+      (res.status === 401 ? " — check BREVO_API_KEY." : "")
+  );
   return NextResponse.json({ error: "server_error" }, { status: 502 });
 }

--- a/components/newsletter-section.tsx
+++ b/components/newsletter-section.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { usePathname } from "next/navigation";
-import { Mail } from "lucide-react";
+import { Mail, MailCheck } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -17,6 +17,11 @@ export function NewsletterSection({ dict }: NewsletterSectionProps) {
   const locale = pathname?.startsWith("/en") ? "en" : "th";
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
+  // Success replaces the form instead of firing a toast: "check your inbox, look
+  // in spam, click the link" is an instruction to act on, and a message that
+  // fades after four seconds is the wrong home for one. Errors stay as toasts —
+  // they're short and the reader needs to stay on the field to fix them.
+  const [sent, setSent] = useState(false);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -31,8 +36,8 @@ export function NewsletterSection({ dict }: NewsletterSectionProps) {
       const data = await res.json().catch(() => ({}));
 
       if (res.ok) {
-        toast.success(dict.home.newsletterSuccess);
         setEmail("");
+        setSent(true);
       } else if (res.status === 409 || data?.error === "duplicate") {
         toast.info(dict.home.newsletterDuplicate);
       } else if (res.status === 400 || data?.error === "invalid_email") {
@@ -57,17 +62,40 @@ export function NewsletterSection({ dict }: NewsletterSectionProps) {
 
           <div className="relative flex flex-col items-center gap-6">
             <div className="flex h-14 w-14 items-center justify-center rounded-full bg-primary-foreground/10">
-              <Mail className="h-7 w-7" aria-hidden="true" />
+              {sent ? (
+                <MailCheck className="h-7 w-7" aria-hidden="true" />
+              ) : (
+                <Mail className="h-7 w-7" aria-hidden="true" />
+              )}
             </div>
 
             <h2 className="text-balance text-3xl font-bold md:text-4xl">
               {dict.home.sectionNewsletter}
             </h2>
 
-            <p className="max-w-lg text-pretty text-primary-foreground/80">
-              {dict.home.newsletterSubtitle}
-            </p>
+            {sent ? (
+              <p
+                role="status"
+                className="max-w-lg text-pretty text-base leading-relaxed text-primary-foreground"
+              >
+                {dict.home.newsletterSuccess}
+              </p>
+            ) : (
+              <p className="max-w-lg text-pretty text-primary-foreground/80">
+                {dict.home.newsletterSubtitle}
+              </p>
+            )}
 
+            {sent ? (
+              <Button
+                type="button"
+                onClick={() => setSent(false)}
+                variant="outline"
+                className="h-11 border-primary-foreground/30 bg-transparent text-primary-foreground hover:bg-primary-foreground/10"
+              >
+                {dict.home.newsletterAnother}
+              </Button>
+            ) : (
             <form
               onSubmit={handleSubmit}
               className="flex w-full max-w-md flex-col gap-3 sm:flex-row"
@@ -93,10 +121,13 @@ export function NewsletterSection({ dict }: NewsletterSectionProps) {
                 {dict.home.newsletterButton}
               </Button>
             </form>
+            )}
 
-            <p className="text-xs text-primary-foreground/60">
-              {dict.home.newsletterDisclaimer}
-            </p>
+            {!sent && (
+              <p className="text-xs text-primary-foreground/60">
+                {dict.home.newsletterDisclaimer}
+              </p>
+            )}
           </div>
         </div>
       </div>

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -91,8 +91,14 @@ const dictionaries = {
       newsletterPlaceholder: "กรอกอีเมลของคุณ",
       newsletterButton: "สมัครรับข่าว",
       newsletterDisclaimer: "เราจะไม่ส่งสแปมให้คุณ สามารถยกเลิกได้ตลอดเวลา",
-      newsletterSuccess: "สมัครรับข่าวสารเรียบร้อยแล้ว ขอบคุณค่ะ",
-      newsletterDuplicate: "อีเมลนี้สมัครรับข่าวไว้แล้ว",
+      newsletterSuccess:
+        "ส่งอีเมลยืนยันไปแล้ว กรุณาตรวจสอบกล่องจดหมายของคุณ (รวมถึงอีเมลขยะ) แล้วกดลิงก์ยืนยันเพื่อเริ่มรับข่าวสาร",
+      newsletterDuplicate: "อีเมลนี้สมัครไว้แล้ว หรือกำลังรอการยืนยัน",
+      newsletterAnother: "สมัครด้วยอีเมลอื่น",
+      newsletterConfirmedTitle: "ยืนยันเรียบร้อยแล้ว",
+      newsletterConfirmed:
+        "ขอบคุณที่สมัครรับข่าวสาร ต่อจากนี้ข่าวสาร กิจกรรม และประกาศจากสมาคม ECTI จะถูกส่งไปยังอีเมลของคุณ",
+      newsletterBackHome: "กลับสู่หน้าแรก",
       newsletterInvalid: "กรุณากรอกอีเมลให้ถูกต้อง",
       newsletterError: "เกิดข้อผิดพลาด กรุณาลองใหม่อีกครั้ง",
     },
@@ -425,8 +431,14 @@ const dictionaries = {
       newsletterPlaceholder: "Enter your email",
       newsletterButton: "Subscribe",
       newsletterDisclaimer: "We respect your privacy. Unsubscribe at any time.",
-      newsletterSuccess: "You're subscribed. Thank you!",
-      newsletterDuplicate: "This email is already subscribed.",
+      newsletterSuccess:
+        "We've sent a confirmation email. Please check your inbox (and your spam folder), then click the link to finish subscribing.",
+      newsletterDuplicate: "This email is already subscribed, or waiting to be confirmed.",
+      newsletterAnother: "Subscribe another email",
+      newsletterConfirmedTitle: "You're subscribed",
+      newsletterConfirmed:
+        "Thank you for subscribing. News, events and announcements from the ECTI Association will now be sent to your email.",
+      newsletterBackHome: "Back to home",
       newsletterInvalid: "Please enter a valid email address.",
       newsletterError: "Something went wrong. Please try again.",
     },


### PR DESCRIPTION
ปิดงาน Part A ของระบบรับข่าวสาร — เปลี่ยนปลายทางของ `/api/subscribe`
จาก Strapi มาเป็น Brevo และรื้อ UX ตอนสมัคร/ยืนยันใหม่

## ทำอะไรบ้าง

### 1. สมัครรับข่าวสารผ่าน Brevo แบบ double opt-in
เดิมกรอกอีเมลแล้วเข้า list เลย ตอนนี้ Brevo จะส่งเมลยืนยันไปก่อน
ต้องกดลิงก์ในเมลถึงจะเข้า list จริง

ทำไมต้อง double opt-in
- อีเมลพิมพ์ผิด หรือคนไม่หวังดีกรอกอีเมลชาวบ้าน จะไม่เข้า list
- การกดลิงก์คือหลักฐานการยินยอมตาม PDPA
- ค่า deliverability ดีกว่า เพราะ list มีแต่คนที่ยืนยันแล้วจริง

API key เก็บไว้ฝั่ง server เท่านั้น (`.env.local`) ไม่หลุดไป client

### 2. กันสมัครซ้ำ
endpoint `doubleOptinConfirmation` ของ Brevo **ตอบสำเร็จเสมอ** ต่อให้
อีเมลนั้นอยู่ใน list แล้ว มันแค่ส่งเมลยืนยันซ้ำ เลยต้องเช็คเองก่อนยิง
ถ้าเจอว่าอยู่ใน list แล้วจะตอบ 409 และขึ้นข้อความว่าสมัครไว้แล้ว

2 เคสที่ยังปล่อยให้ส่งซ้ำได้ เพราะมันถูกต้องแล้ว
- เคยกดยกเลิกรับข่าว → การสมัครใหม่ต้องผ่านการยืนยันเพื่อเก็บหลักฐานรอบใหม่
- สมัครแล้วยังไม่ได้กดยืนยัน → เมลอาจตกหล่น ส่งลิงก์ใหม่คือสิ่งที่ต้องการ

ถ้าตัวเช็คพังเอง (Brevo ล่ม) จะปล่อยผ่านไปสมัครต่อ ไม่ทำให้ฟอร์มใช้ไม่ได้

### 3. เปลี่ยนข้อความสำเร็จจาก toast เป็นข้อความค้าง
เดิมใช้ toast ซึ่งเด้งแป๊บเดียวแล้วหาย แต่ข้อความนี้เป็น**คำสั่งให้ไปทำต่อ**
(ไปเช็คกล่องจดหมาย ดูในเมลขยะ กดลิงก์) ไม่ควรหายไปเอง
ตอนนี้พอสมัครสำเร็จ ฟอร์มจะกลายเป็นข้อความยืนยันค้างไว้ พร้อมปุ่ม
"สมัครด้วยอีเมลอื่น" — รูปแบบเดียวกับฟอร์มติดต่อที่มีอยู่แล้ว

ข้อความ error ยังเป็น toast เหมือนเดิม เพราะสั้น และคนยังต้องอยู่ที่ช่องกรอกเพื่อแก้

### 4. หน้ายืนยันแยก `/[locale]/newsletter/confirmed`
ปลายทางหลังกดลิงก์ในเมล เดิมเด้งกลับหน้าแรกพร้อม toast ซึ่งคนพลาดได้ง่ายมาก
ตอนนี้เป็นหน้าของตัวเอง เปิดซ้ำได้ รีเฟรชได้ ไม่ขึ้นกับจังหวะฝั่ง client
และตั้ง `noindex` ไว้เพราะไม่ควรไปโผล่ใน Google

## ไฟล์ที่แก้

| ไฟล์ | |
|---|---|
| `app/api/subscribe/route.ts` | ยิง Brevo DOI + เช็คสมัครซ้ำ |
| `components/newsletter-section.tsx` | สำเร็จแล้วแทนที่ฟอร์ม ไม่ใช้ toast |
| `app/[locale]/(site)/newsletter/confirmed/page.tsx` | หน้ายืนยัน (ใหม่) |
| `lib/i18n.ts` | ข้อความ th/en |

## ตัวแปรที่ต้องตั้งเพิ่ม

ต้องเพิ่มใน Vercel ก่อน deploy ไม่งั้นฟอร์มจะขึ้น error

| ตัวแปร | |
|---|---|
| `BREVO_API_KEY` | API key จาก Brevo (server-side เท่านั้น) |
| `BREVO_LIST_ID` | `4` (list ชื่อ ECTI News) |
| `BREVO_DOI_TEMPLATE_ID` | `3` (เทมเพลตเมลยืนยัน) |
| `NEXT_PUBLIC_SITE_URL` | URL ของเว็บ ใช้สร้างลิงก์กลับหลังกดยืนยัน |

ถ้าตัวไหนขาด route จะ log บอกชื่อตัวที่ขาดตรง ๆ ไม่ใช่ 500 เปล่า ๆ

## ทดสอบแล้ว

- สมัครด้วยอีเมลใหม่ → ได้เมลยืนยัน → กดลิงก์ → เข้าหน้ายืนยัน → เข้า list จริง
- สมัครด้วยอีเมลที่อยู่ใน list แล้ว → ได้ 409 ขึ้นข้อความว่าสมัครไว้แล้ว ไม่มีเมลถูกส่ง
- อีเมลผิดรูปแบบ → 400
- ตอนนี้ list `ECTI News` มีคนยืนยันแล้ว 3 คน
- `tsc --noEmit` ผ่าน

## ยังไม่ได้ทำในรอบนี้

- rate limiting ที่ `/api/subscribe` — จะทำแยก issue
- ยืนยัน domain `ecti-thailand.org` ใน Brevo (ตอนนี้ผู้ส่งยังถูกเปลี่ยนเป็น `@brevosend.com`)