### PR TITLE
feat(newsletter): rate limit the subscribe endpoint

### DIFF
--- a/app/api/subscribe/route.ts
+++ b/app/api/subscribe/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { rateLimit } from "@/lib/rate-limit";
 
 // Newsletter signup → Brevo, using Brevo's double opt-in endpoint: it stores the
 // address as *unconfirmed* and mails a confirmation link, and only a click on
@@ -16,6 +17,56 @@ const DOI_TEMPLATE_ID = Number(process.env.BREVO_DOI_TEMPLATE_ID);
 const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000").replace(/\/+$/, "");
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const HOUR = 60 * 60 * 1000;
+
+// Sized for how people actually behave: nobody subscribes their household from
+// one address more than a handful of times an hour, and three confirmation
+// mails for the same address in a day is already generous for "it didn't
+// arrive, send it again".
+const PER_IP_LIMIT = 5;
+const PER_IP_WINDOW = HOUR;
+const PER_EMAIL_LIMIT = 3;
+const PER_EMAIL_WINDOW = 24 * HOUR;
+
+/**
+ * Best-effort client address. Vercel puts the real one first in
+ * x-forwarded-for; locally there is no proxy and every caller collapses into
+ * one "unknown" bucket, which is fine — the limit still holds in dev, it just
+ * holds for everyone at once.
+ */
+function clientIp(request: Request): string {
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) return forwarded.split(",")[0].trim();
+  return request.headers.get("x-real-ip") ?? "unknown";
+}
+
+/**
+ * Rejects anything that didn't come from our own pages.
+ *
+ * Browsers send Origin on every POST, so a real submission always has one that
+ * matches the host serving it. A script pointed straight at this route
+ * generally doesn't — cheap to check, and it doesn't need a list of allowed
+ * hosts to maintain, so preview deploys and localhost work unchanged.
+ */
+function sameOrigin(request: Request): boolean {
+  const origin = request.headers.get("origin");
+  if (!origin) return false;
+
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+  try {
+    return new URL(origin).host === host;
+  } catch {
+    return false;
+  }
+}
+
+function tooManyRequests(retryAfter: number) {
+  return NextResponse.json(
+    { error: "rate_limited" },
+    { status: 429, headers: { "Retry-After": String(retryAfter) } }
+  );
+}
 
 /** Names what's missing so a misconfigured deploy says so instead of 500-ing blind. */
 function missingConfig(): string[] {
@@ -56,11 +107,29 @@ async function findContact(email: string): Promise<{ listIds?: number[]; emailBl
 }
 
 export async function POST(request: Request) {
-  let body: { email?: string; locale?: string };
+  if (!sameOrigin(request)) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  let body: { email?: string; locale?: string; botcheck?: unknown };
   try {
     body = await request.json();
   } catch {
     return NextResponse.json({ error: "invalid_request" }, { status: 400 });
+  }
+
+  // Honeypot: the field is hidden, so only a bot filling the form blindly sets
+  // it. Answer as if it worked — telling it apart from a real signup only
+  // teaches whoever wrote it to stop filling the field.
+  if (body.botcheck) {
+    return NextResponse.json({ ok: true }, { status: 201 });
+  }
+
+  // Counted before the email is even validated, so spraying junk addresses
+  // costs the same budget as spraying real ones.
+  const byIp = rateLimit(`ip:${clientIp(request)}`, PER_IP_LIMIT, PER_IP_WINDOW);
+  if (!byIp.ok) {
+    return tooManyRequests(byIp.retryAfter);
   }
 
   const email = (body.email ?? "").trim().toLowerCase();
@@ -84,6 +153,14 @@ export async function POST(request: Request) {
   const existing = await findContact(email);
   if (existing && existing.listIds?.includes(LIST_ID) && !existing.emailBlacklisted) {
     return NextResponse.json({ error: "duplicate" }, { status: 409 });
+  }
+
+  // Past the duplicate check, so this only ever counts mails we're about to
+  // actually send. It's the cap on "resend the link, it never arrived" —
+  // legitimate, but not fifty times.
+  const byEmail = rateLimit(`email:${email}`, PER_EMAIL_LIMIT, PER_EMAIL_WINDOW);
+  if (!byEmail.ok) {
+    return tooManyRequests(byEmail.retryAfter);
   }
 
   let res: Response;

--- a/components/newsletter-section.tsx
+++ b/components/newsletter-section.tsx
@@ -22,6 +22,9 @@ export function NewsletterSection({ dict }: NewsletterSectionProps) {
   // fades after four seconds is the wrong home for one. Errors stay as toasts —
   // they're short and the reader needs to stay on the field to fix them.
   const [sent, setSent] = useState(false);
+  // Honeypot, same trick the contact form uses: hidden from people, so anything
+  // that ticks it is filling the form without looking at it.
+  const [botcheck, setBotcheck] = useState(false);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -31,7 +34,7 @@ export function NewsletterSection({ dict }: NewsletterSectionProps) {
       const res = await fetch("/api/subscribe", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email, locale }),
+        body: JSON.stringify({ email, locale, botcheck }),
       });
       const data = await res.json().catch(() => ({}));
 
@@ -40,6 +43,8 @@ export function NewsletterSection({ dict }: NewsletterSectionProps) {
         setSent(true);
       } else if (res.status === 409 || data?.error === "duplicate") {
         toast.info(dict.home.newsletterDuplicate);
+      } else if (res.status === 429) {
+        toast.error(dict.home.newsletterTooMany);
       } else if (res.status === 400 || data?.error === "invalid_email") {
         toast.error(dict.home.newsletterInvalid);
       } else {
@@ -113,6 +118,18 @@ export function NewsletterSection({ dict }: NewsletterSectionProps) {
                 className="h-11 flex-1 border-primary-foreground/20 bg-primary-foreground/10 text-primary-foreground placeholder:text-primary-foreground/50 focus-visible:ring-primary-foreground/30"
                 required
               />
+              <input
+                type="checkbox"
+                name="botcheck"
+                checked={botcheck}
+                onChange={(e) => setBotcheck(e.target.checked)}
+                className="hidden"
+                style={{ display: "none" }}
+                tabIndex={-1}
+                autoComplete="off"
+                aria-hidden="true"
+              />
+
               <Button
                 type="submit"
                 disabled={loading}

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -99,6 +99,7 @@ const dictionaries = {
       newsletterConfirmed:
         "ขอบคุณที่สมัครรับข่าวสาร ต่อจากนี้ข่าวสาร กิจกรรม และประกาศจากสมาคม ECTI จะถูกส่งไปยังอีเมลของคุณ",
       newsletterBackHome: "กลับสู่หน้าแรก",
+      newsletterTooMany: "คุณกดสมัครบ่อยเกินไป กรุณารอสักครู่แล้วลองใหม่อีกครั้ง",
       newsletterInvalid: "กรุณากรอกอีเมลให้ถูกต้อง",
       newsletterError: "เกิดข้อผิดพลาด กรุณาลองใหม่อีกครั้ง",
     },
@@ -439,6 +440,7 @@ const dictionaries = {
       newsletterConfirmed:
         "Thank you for subscribing. News, events and announcements from the ECTI Association will now be sent to your email.",
       newsletterBackHome: "Back to home",
+      newsletterTooMany: "Too many attempts. Please wait a moment and try again.",
       newsletterInvalid: "Please enter a valid email address.",
       newsletterError: "Something went wrong. Please try again.",
     },

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,65 @@
+/**
+ * A small fixed-window rate limiter kept in the server process's memory.
+ *
+ * Deliberately dependency-free. The thing being protected is Brevo's free
+ * quota — 300 confirmation emails a day, shared by everyone who ever wants to
+ * subscribe — so the job is to stop a form being hammered, not to withstand a
+ * determined attack.
+ *
+ * What this does NOT do, and it matters: serverless instances are recycled and
+ * requests fan out across several of them, so counters are neither shared nor
+ * permanent. Someone patient enough to spread requests out, or lucky enough to
+ * land on a cold instance, gets a fresh budget. Trading that away buys zero
+ * dependencies and zero setup, which is the right trade until real abuse shows
+ * up in the logs; the upgrade path is a shared store (Upstash, Vercel KV) and
+ * only the guts of this file change.
+ */
+
+interface Window {
+  count: number;
+  resetAt: number;
+}
+
+const windows = new Map<string, Window>();
+
+/** Above this many tracked keys, drop the expired ones before adding more. */
+const SWEEP_THRESHOLD = 500;
+
+function sweep(now: number) {
+  for (const [key, window] of windows) {
+    if (window.resetAt <= now) windows.delete(key);
+  }
+}
+
+export interface RateLimitResult {
+  /** False once the caller has spent its budget for the current window. */
+  ok: boolean;
+  /** Seconds until the window resets — for the Retry-After header. */
+  retryAfter: number;
+}
+
+/**
+ * Counts one hit against `key` and reports whether it was within `limit` for
+ * the current `windowMs`. Calling this *is* the hit; there is no separate
+ * consume step, so a rejected request still counts and hammering never resets
+ * the clock.
+ */
+export function rateLimit(key: string, limit: number, windowMs: number): RateLimitResult {
+  const now = Date.now();
+
+  if (windows.size > SWEEP_THRESHOLD) sweep(now);
+
+  const existing = windows.get(key);
+
+  if (!existing || existing.resetAt <= now) {
+    windows.set(key, { count: 1, resetAt: now + windowMs });
+    return { ok: true, retryAfter: 0 };
+  }
+
+  existing.count += 1;
+
+  return {
+    ok: existing.count <= limit,
+    retryAfter: Math.max(1, Math.ceil((existing.resetAt - now) / 1000)),
+  };
+}


### PR DESCRIPTION
Closes #85 

## ปัญหา

`/api/subscribe` ไม่ต้อง login ไม่มีการจำกัดจำนวนครั้ง และทุก request ที่ผ่าน
= เมลยืนยัน 1 ฉบับจากโควตาฟรีของ Brevo ที่มีแค่ **300 ฉบับ/วัน**

ยิงรัว ๆ ไม่กี่วินาทีโควตาก็หมด แล้วคนที่อยากสมัครจริงจะไม่ได้รับเมลยืนยัน
ไปทั้งวัน โดยที่หน้าเว็บดูเหมือนทำงานปกติทุกอย่าง — พังแบบเงียบ ๆ

และถ้าโดนใช้ยิงเมลไปหาคนที่ไม่ได้ขอ จะโดนกด spam กระทบ sender reputation
ของทั้งบัญชี ซึ่งกู้คืนยากมาก ยิ่งตอนนี้ยังไม่ได้ยืนยัน domain
ผู้ส่งเลยเป็น `@brevosend.com` ที่แชร์กับคนอื่น ยิ่งกระทบเป็นวงกว้าง

## วิธีแก้ — ด่าน 4 ชั้น เรียงจากถูกที่สุดไปแพงที่สุด

**1. เช็ค `Origin`**
เบราว์เซอร์ส่ง header นี้มาทุก POST คำขอจริงจากหน้าเว็บเราจึงตรงกับ host
ที่เสิร์ฟหน้านั้นเสมอ ส่วนสคริปต์ที่ยิงตรงเข้า endpoint ส่วนใหญ่ไม่มี → 403
เทียบกับ host ที่เข้ามา ไม่ต้อง hardcode รายชื่อโดเมน localhost กับ
preview deploy เลยใช้ได้เลยโดยไม่ต้องตั้งค่าอะไรเพิ่ม

**2. honeypot**
ช่อง `botcheck` ที่ซ่อนไว้ คนมองไม่เห็นจึงไม่มีทางติ๊ก บอทที่กรอกทุกช่องจะติ๊ก
ถ้ามีค่ามา → ตอบ `201` เหมือนสำเร็จแต่ไม่ส่งอะไรจริง
(ไม่บอกว่าจับได้ เพราะบอกไปก็แค่สอนให้คนเขียนบอทเลี่ยงช่องนี้)
ใช้วิธีเดียวกับฟอร์มติดต่อที่มีอยู่แล้วในโปรเจกต์

**3. จำกัดตาม IP — 5 ครั้ง/ชั่วโมง**
นับ **ก่อน** ตรวจรูปแบบอีเมล ทำให้ยิงอีเมลมั่ว ๆ เปลืองโควตาเท่ากับยิงอีเมลจริง
ไม่งั้นจะเลี่ยงได้ด้วยการส่งค่าขยะเข้ามา

**4. จำกัดตามอีเมล — 3 ฉบับ/วัน**
วางไว้ **หลัง** การเช็คสมัครซ้ำ จึงนับเฉพาะเมลที่จะถูกส่งออกจริง
เคส "ลิงก์ยืนยันไม่มา ขอใหม่" ยังทำได้ แต่ไม่ใช่ 50 รอบ

เกิน limit → `429` พร้อม header `Retry-After` และข้อความ th/en

## ข้อจำกัดที่ตั้งใจยอมรับ

ตัวนับเก็บไว้ใน memory ของ process — Vercel เป็น serverless ที่รีไซเคิล
instance และกระจาย request ข้ามหลาย instance แปลว่าตัวนับไม่แชร์กันและไม่ถาวร
**กันคนกดรัวได้ แต่กันคนที่ตั้งใจโจมตีจริงจังไม่ได้**

ยอมแลกเพราะได้ไม่ต้องลง dependency ไม่ต้องสมัคร service ใหม่ ไม่ต้องตั้งค่าอะไรเลย
ซึ่งคุ้มกว่าจนกว่าจะเห็นการยิงจริงใน log — ถ้าวันนั้นมาถึง ย้ายไปใช้ Upstash Redis
โดยแก้แค่ไส้ในของ `lib/rate-limit.ts` ไฟล์เดียว ไม่ต้องแตะ route
เขียนข้อจำกัดนี้ไว้ใน comment หัวไฟล์แล้ว

## ไฟล์ที่แก้

| ไฟล์ | |
|---|---|
| `lib/rate-limit.ts` | ตัวนับ fixed-window (ใหม่) กวาด entry หมดอายุทิ้งเมื่อเกิน 500 key |
| `app/api/subscribe/route.ts` | ด่าน 4 ชั้นข้างบน |
| `components/newsletter-section.tsx` | ช่อง honeypot + จับ 429 |
| `lib/i18n.ts` | `newsletterTooMany` th/en |

ไม่มีตัวแปร env เพิ่ม ตัวเลข limit อยู่รวมกันที่หัวไฟล์ route ปรับที่เดียว

## ทดสอบแล้ว

| เคส | ผล |
|---|---|
| ยิงตรงเข้า endpoint ไม่มี `Origin` | `403 forbidden` |
| honeypot ถูกติ๊ก | `201 ok` (ไม่ส่งจริง) |
| ยิงซ้ำครั้งที่ 1–5 | `409 duplicate` |
| ยิงซ้ำครั้งที่ 6 | `429 rate_limited` + `Retry-After: 3598` |

ตรวจกับ Brevo หลังเทส: contact ในบัญชียังเท่าเดิม 4 / list `ECTI News` ยัง 3 คน
→ ไม่มีเมลถูกส่งออกระหว่างทดสอบเลย

`tsc --noEmit` ผ่าน

## หมายเหตุสำหรับคนรีวิว

ตอน dev ไม่มี proxy ทุก request จึงถูกนับรวมเป็น IP เดียวกันหมด
ถ้าเทสจนติด 429 ให้ restart `pnpm dev` ตัวนับจะเคลียร์ (เก็บใน memory)