### PR TITLE
feat(contact): submit the contact form through our own API route

### DIFF
--- a/app/[locale]/(site)/contact/page.tsx
+++ b/app/[locale]/(site)/contact/page.tsx
@@ -137,6 +137,8 @@ export default async function ContactPage({ params }: PageProps) {
               formSend: dict.contact.formSend,
               formSuccess: dict.contact.formSuccess,
               formError: dict.contact.formError,
+              formTooMany: dict.contact.formTooMany,
+              formInvalid: dict.contact.formInvalid,
             }}
           />
 

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,146 @@
+import { NextResponse } from "next/server";
+import { rateLimit } from "@/lib/rate-limit";
+import { sameOrigin, clientIp } from "@/lib/request-guards";
+
+// Contact form → Web3Forms, proxied through here instead of straight from the
+// browser. The access key used to be NEXT_PUBLIC_, which put it in the client
+// bundle for anyone to read and POST with from anywhere. Moving it server-side
+// hides the key, but that isn't really the point: what we get back is a
+// chokepoint we own, where a rate limit and real validation can live. Web3Forms
+// alone gives us neither — its own controls are in their dashboard.
+//
+// This route stays public, so the limits below are what stands between a script
+// and the association's inbox.
+
+const WEB3FORMS_API = "https://api.web3forms.com/submit";
+
+const ACCESS_KEY = process.env.WEB3FORMS_ACCESS_KEY;
+
+const HOUR = 60 * 60 * 1000;
+
+// Tighter than the newsletter's 5/hour: subscribing is one click people
+// genuinely retry, whereas writing out a message three times in an hour already
+// means something went wrong. Web3Forms' free tier is 250 submissions a month —
+// a single unattended script would eat that in a minute.
+const PER_IP_LIMIT = 3;
+const PER_IP_WINDOW = HOUR;
+
+/**
+ * Per-field caps. Generous for a person, restrictive for a payload — the point
+ * is that nothing unbounded reaches Web3Forms or the inbox behind it.
+ */
+const MAX_LENGTHS = {
+  name: 100,
+  contact: 150,
+  subject: 150,
+  message: 5000,
+} as const;
+
+/** Refuse an oversized body before reading it into memory. */
+const MAX_BODY_BYTES = 64 * 1024;
+
+type Field = keyof typeof MAX_LENGTHS;
+
+const FIELDS: Field[] = ["name", "contact", "subject", "message"];
+
+function tooManyRequests(retryAfter: number) {
+  return NextResponse.json(
+    { error: "rate_limited" },
+    { status: 429, headers: { "Retry-After": String(retryAfter) } }
+  );
+}
+
+/**
+ * Trims, then requires every field to be present and within its cap.
+ *
+ * Deliberately no email regex on `contact`: the label reads "ช่องทางการติดต่อ
+ * กลับ (อีเมล หรืออื่นๆ)" / "Contact channel (email or other)", so a phone
+ * number or a LINE id is a valid answer. Validating it as an email would reject
+ * exactly what the form asks for.
+ */
+function validate(body: Record<string, unknown>): { values: Record<Field, string> } | { error: string } {
+  const values = {} as Record<Field, string>;
+
+  for (const field of FIELDS) {
+    const raw = body[field];
+    if (typeof raw !== "string") return { error: field };
+
+    const value = raw.trim();
+    if (!value || value.length > MAX_LENGTHS[field]) return { error: field };
+
+    values[field] = value;
+  }
+
+  return { values };
+}
+
+export async function POST(request: Request) {
+  if (!sameOrigin(request)) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  const declaredLength = Number(request.headers.get("content-length") ?? 0);
+  if (declaredLength > MAX_BODY_BYTES) {
+    return NextResponse.json({ error: "too_large" }, { status: 413 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_request" }, { status: 400 });
+  }
+
+  // Honeypot: the field is hidden, so only a bot filling the form blindly sets
+  // it. Answer as if it worked — telling it apart from a real submission only
+  // teaches whoever wrote it to stop ticking the box.
+  if (body.botcheck) {
+    return NextResponse.json({ ok: true }, { status: 201 });
+  }
+
+  // Counted before validation, so spraying malformed bodies costs the same
+  // budget as spraying well-formed ones.
+  const byIp = rateLimit(`contact:${clientIp(request)}`, PER_IP_LIMIT, PER_IP_WINDOW);
+  if (!byIp.ok) {
+    return tooManyRequests(byIp.retryAfter);
+  }
+
+  const result = validate(body);
+  if ("error" in result) {
+    return NextResponse.json({ error: "invalid_input", field: result.error }, { status: 400 });
+  }
+
+  if (!ACCESS_KEY) {
+    console.error("contact: not configured — missing WEB3FORMS_ACCESS_KEY");
+    return NextResponse.json({ error: "server_error" }, { status: 500 });
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(WEB3FORMS_API, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      // Same field names the browser used to send, so the mail that lands in
+      // the inbox reads exactly as it did before.
+      body: JSON.stringify({ access_key: ACCESS_KEY, ...result.values }),
+      cache: "no-store",
+    });
+  } catch (err) {
+    console.error("contact: cannot reach Web3Forms", err);
+    return NextResponse.json({ error: "server_error" }, { status: 502 });
+  }
+
+  // Web3Forms answers 200 with {success:false} for a rejected submission, so
+  // the status alone doesn't say whether the mail went out.
+  const data = await res.json().catch(() => null);
+
+  if (res.ok && data?.success) {
+    return NextResponse.json({ ok: true }, { status: 201 });
+  }
+
+  console.error(
+    `contact: Web3Forms returned ${res.status}: ${JSON.stringify(data)}` +
+      (res.status === 401 || res.status === 403 ? " — check WEB3FORMS_ACCESS_KEY." : "")
+  );
+  return NextResponse.json({ error: "server_error" }, { status: 502 });
+}

--- a/components/contact-form.tsx
+++ b/components/contact-form.tsx
@@ -7,10 +7,11 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Send, CheckCircle2 } from "lucide-react";
 
-// Web3Forms access key routes submissions to the destination inbox. It lives in
-// an env var so the org can change the destination email later (make a new key,
-// swap this value) without touching code. It's used client-side by design.
-const ACCESS_KEY = process.env.NEXT_PUBLIC_WEB3FORMS_ACCESS_KEY;
+// Posts to our own /api/contact, which holds the Web3Forms access key and
+// forwards the message. The key used to live here as NEXT_PUBLIC_ — shipped in
+// the bundle, readable by anyone, and usable from anywhere. More importantly,
+// going straight to Web3Forms left no place to put a rate limit; now there is
+// one, on our side of the request.
 
 interface ContactFormProps {
   labels: {
@@ -23,35 +24,51 @@ interface ContactFormProps {
     formSend: string;
     formSuccess: string;
     formError: string;
+    formTooMany: string;
+    formInvalid: string;
   };
 }
 
 export function ContactForm({ labels }: ContactFormProps) {
   const [submitted, setSubmitted] = useState(false);
   const [sending, setSending] = useState(false);
-  const [error, setError] = useState(false);
+  // Holds the message to show rather than a flag, so "too many attempts" and
+  // "that didn't go through" don't collapse into the same unhelpful line.
+  const [error, setError] = useState<string | null>(null);
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const form = e.currentTarget; // capture before await (currentTarget clears after)
-    setError(false);
+    setError(null);
     setSending(true);
     try {
       const formData = new FormData(form);
-      formData.append("access_key", ACCESS_KEY ?? "");
-      const res = await fetch("https://api.web3forms.com/submit", {
+      const res = await fetch("/api/contact", {
         method: "POST",
-        headers: { Accept: "application/json" },
-        body: formData,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: String(formData.get("name") ?? ""),
+          contact: String(formData.get("contact") ?? ""),
+          subject: String(formData.get("subject") ?? ""),
+          message: String(formData.get("message") ?? ""),
+          // Unchecked checkboxes are absent from FormData, so presence is the
+          // whole signal — a person never sends this.
+          botcheck: formData.get("botcheck") !== null,
+        }),
       });
-      const data = await res.json();
-      if (data.success) {
+
+      if (res.ok) {
+        form.reset();
         setSubmitted(true);
+      } else if (res.status === 429) {
+        setError(labels.formTooMany);
+      } else if (res.status === 400 || res.status === 413) {
+        setError(labels.formInvalid);
       } else {
-        setError(true);
+        setError(labels.formError);
       }
     } catch {
-      setError(true);
+      setError(labels.formError);
     } finally {
       setSending(false);
     }
@@ -95,6 +112,7 @@ export function ContactForm({ labels }: ContactFormProps) {
               name="name"
               type="text"
               required
+              maxLength={100}
               placeholder={labels.formName}
               className="border-input"
             />
@@ -108,6 +126,7 @@ export function ContactForm({ labels }: ContactFormProps) {
               name="contact"
               type="text"
               required
+              maxLength={150}
               placeholder={labels.formContactPlaceholder}
               className="border-input"
             />
@@ -121,6 +140,7 @@ export function ContactForm({ labels }: ContactFormProps) {
               name="subject"
               type="text"
               required
+              maxLength={150}
               placeholder={labels.formSubject}
               className="border-input"
             />
@@ -134,6 +154,7 @@ export function ContactForm({ labels }: ContactFormProps) {
               name="message"
               rows={5}
               required
+              maxLength={5000}
               placeholder={labels.formMessage}
               className="border-input"
             />
@@ -170,7 +191,7 @@ export function ContactForm({ labels }: ContactFormProps) {
 
           {error && (
             <p className="text-sm text-destructive" role="alert">
-              {labels.formError}
+              {error}
             </p>
           )}
         </form>

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -285,6 +285,9 @@ const dictionaries = {
       formSend: "ส่งข้อความ",
       formSuccess: "ได้รับข้อความของคุณแล้ว ขอบคุณที่ติดต่อ ECTI",
       formError: "ส่งข้อความไม่สำเร็จ กรุณาลองใหม่อีกครั้ง หรือติดต่อทางอีเมลโดยตรง",
+      formTooMany:
+        "คุณส่งข้อความบ่อยเกินไป กรุณารอสักครู่แล้วลองใหม่อีกครั้ง",
+      formInvalid: "กรุณากรอกข้อมูลให้ครบทุกช่อง และไม่ยาวเกินกำหนด",
       mapTitle: "ตำแหน่งที่ตั้ง",
       socialTitle: "ติดตามเราได้ที่",
     },
@@ -628,6 +631,8 @@ const dictionaries = {
       formSuccess: "We've received your message. Thank you for contacting ECTI",
       formError:
         "Couldn't send your message. Please try again, or email us directly.",
+      formTooMany: "Too many messages. Please wait a moment and try again.",
+      formInvalid: "Please fill in every field, and keep them within the limits.",
       mapTitle: "Location",
       socialTitle: "Follow Us",
     },

--- a/lib/request-guards.ts
+++ b/lib/request-guards.ts
@@ -1,0 +1,40 @@
+/**
+ * Checks every public POST route makes before it does any work.
+ *
+ * Lifted out of app/api/subscribe/route.ts once app/api/contact/route.ts needed
+ * the same two. Security checks that exist in two copies drift — one gets a fix
+ * and the other doesn't, and nobody notices because both still return 200 on
+ * the happy path.
+ */
+
+/**
+ * Rejects anything that didn't come from our own pages.
+ *
+ * Browsers send Origin on every POST, so a real submission always has one that
+ * matches the host serving it. A script pointed straight at this route
+ * generally doesn't — cheap to check, and it doesn't need a list of allowed
+ * hosts to maintain, so preview deploys and localhost work unchanged.
+ */
+export function sameOrigin(request: Request): boolean {
+  const origin = request.headers.get("origin");
+  if (!origin) return false;
+
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+  try {
+    return new URL(origin).host === host;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Best-effort client address. Vercel puts the real one first in
+ * x-forwarded-for; locally there is no proxy and every caller collapses into
+ * one "unknown" bucket, which is fine — the limit still holds in dev, it just
+ * holds for everyone at once.
+ */
+export function clientIp(request: Request): string {
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) return forwarded.split(",")[0].trim();
+  return request.headers.get("x-real-ip") ?? "unknown";
+}


### PR DESCRIPTION
## สิ่งที่เปลี่ยน

ฟอร์มติดต่อไม่ยิงไป Web3Forms ตรงจากเบราว์เซอร์อีกแล้ว แต่ยิงมาที่
`/api/contact` ของเราเอง แล้วให้ route นั้นส่งต่อ

- ย้าย key จาก `NEXT_PUBLIC_WEB3FORMS_ACCESS_KEY` → `WEB3FORMS_ACCESS_KEY`
- rate limit 3 ครั้ง/ชั่วโมง/IP นับ**ก่อน** validate
- จำกัดความยาวรายฟิลด์
- honeypot ที่ตอบเหมือนสำเร็จ
- แยก `sameOrigin()` / `clientIp()` ออกมาที่ `lib/request-guards.ts`
- ฟอร์มอ่าน status code เพื่อแยก "ส่งถี่เกินไป" ออกจาก "ส่งไม่สำเร็จ"
  (เพิ่ม dictionary สองคำ)

## ทำไมต้องเปลี่ยน

`NEXT_PUBLIC_` แปลว่า key อยู่ใน bundle ฝั่ง client ซึ่งไม่เหมาะกับค่าที่
ควรเป็นความลับ แต่นั่นเป็นครึ่งที่เล็กกว่า

ครึ่งที่ใหญ่กว่าคือการยิงตรงทำให้**ไม่มีที่ให้วาง rate limit เลย** —
ตัวควบคุมของ Web3Forms อยู่ในแดชบอร์ดของเขา ไม่ได้อยู่ใน repo นี้
โควตา free tier คือ 250 ครั้ง/เดือน ถ้าหมด ฟอร์มติดต่อของสมาคมก็ใช้ไม่ได้
จนกว่าจะขึ้นรอบใหม่ การมี route ของตัวเองคือการมีจุดที่เราคุมได้

rate limit นับก่อน validate โดยตั้งใจ — การยิง payload ขยะจะได้เปลืองโควตา
เท่ากับการยิงของจริง

ตั้งใจ**ไม่**ใส่ regex อีเมลกับช่อง `contact` เพราะช่องนั้นถามว่า
"ช่องทางการติดต่อกลับ (อีเมล หรืออื่นๆ)" เบอร์โทรหรือ LINE id
เป็นคำตอบที่ถูกต้อง ถ้าบังคับเป็นอีเมลจะปฏิเสธสิ่งที่ฟอร์มถามหาเอง

`sameOrigin()` และ `clientIp()` แยกออกมาเพราะ `/api/subscribe` ต้องใช้
สองตัวเดียวกัน การตรวจความปลอดภัยที่มีสองก๊อปปี้จะค่อยๆ ต่างกัน —
อันหนึ่งได้ fix อีกอันไม่ได้ และทั้งคู่ยังตอบ 200 บนทางปกติ เลยไม่มีใครเห็น

Closes #101

## ตรวจสอบยังไง

- [x] `pnpm build` ผ่าน
- [x] `npx tsc --noEmit` ผ่าน
- [x] ตั้ง `WEB3FORMS_ACCESS_KEY` (ไม่ใช่ `NEXT_PUBLIC_...`) แล้วส่งฟอร์มจริง
      → เข้าอีเมลปลายทาง
- [ ] ส่งเกิน 3 ครั้งในชั่วโมงเดียว → ได้ 429 และหน้าเว็บขึ้นข้อความ
      "ส่งถี่เกินไป" ไม่ใช่ error ทั่วไป
- [ ] `POST /api/contact` โดยไม่มี header `Origin` → 403

## ผลกระทบ

- **Breaking change:** ไม่มีต่อผู้ใช้
- **ต้องตั้ง env ใหม่:** ✅ **มี** — ต้องเพิ่ม `WEB3FORMS_ACCESS_KEY` ใน Vercel
  ก่อน merge ตัวเก่า `NEXT_PUBLIC_WEB3FORMS_ACCESS_KEY` ลบได้หลัง deploy แล้ว
- **ต้องแก้ข้อมูลใน Strapi:** ไม่มี
- **ต้อง deploy พร้อมกันกับอีก repo:** ไม่

## หมายเหตุ

งานนี้ค้างอยู่ใน working tree มาก่อน ไม่ได้เขียนใหม่ใน PR นี้ —
แยกออกมาเป็น PR ของตัวเองเพื่อให้รีวิวแยกจากงานความปลอดภัยได้
PR #104 ต่อยอดจาก branch นี้และแก้จุดที่ยังเหลือใน `lib/request-guards.ts`

## Checklist

- [x] commit message เป็นรูปแบบ `<type>(<scope>): <description>`
- [ ] ทดสอบทั้ง locale `th` และ `en`
- [x] ไม่มี secret หรือ key หลุดเข้า commit
