### PR TITLE
fix(contact): send the message through Brevo instead of Web3Forms

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -2,32 +2,52 @@ import { NextResponse } from "next/server";
 import { rateLimit } from "@/lib/rate-limit";
 import { sameOrigin, clientIp } from "@/lib/request-guards";
 
-// Contact form → Web3Forms, proxied through here instead of straight from the
-// browser. The access key used to be NEXT_PUBLIC_, which put it in the client
-// bundle for anyone to read and POST with from anywhere. Moving it server-side
-// hides the key, but that isn't really the point: what we get back is a
-// chokepoint we own, where a rate limit and real validation can live. Web3Forms
-// alone gives us neither — its own controls are in their dashboard.
+// Contact form → the association's inbox, as a Brevo transactional email.
+//
+// This route exists to be a chokepoint we own, where a rate limit and real
+// validation can live — a form that posts straight to a third party gives us
+// neither, and leaves its access key in the client bundle for anyone to read.
+//
+// It used to forward to Web3Forms. That does not work from a server: Web3Forms'
+// free tier accepts submissions from the browser only, and answers a server-side
+// POST with 403 "Use our API in client side ... (Pro plan is required)". So
+// routing through here — the thing that makes the rate limit possible — is
+// exactly what their free tier rules out.
+//
+// Brevo has no such restriction, its transactional API is built to be called
+// from a server, and we already use it for the newsletter, so the key and the
+// account are already here. Its free tier is 300 emails a day against
+// Web3Forms' 250 a month.
 //
 // This route stays public, so the limits below are what stands between a script
 // and the association's inbox.
 
-const WEB3FORMS_API = "https://api.web3forms.com/submit";
+const BREVO_SEND_API = "https://api.brevo.com/v3/smtp/email";
 
-const ACCESS_KEY = process.env.WEB3FORMS_ACCESS_KEY;
+// Trimmed: a value pasted into a dashboard picks up a trailing newline more
+// often than anyone would like, and an API key with whitespace on the end fails
+// in a way that looks nothing like the cause.
+const API_KEY = process.env.BREVO_API_KEY?.trim();
+/** Must be a sender Brevo has verified — not the visitor's address. */
+const SENDER_EMAIL = process.env.CONTACT_SENDER_EMAIL?.trim();
+const SENDER_NAME = process.env.CONTACT_SENDER_NAME?.trim() || "ECTI Website";
+/** Where the message lands. */
+const TO_EMAIL = process.env.CONTACT_TO_EMAIL?.trim();
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 const HOUR = 60 * 60 * 1000;
 
 // Tighter than the newsletter's 5/hour: subscribing is one click people
 // genuinely retry, whereas writing out a message three times in an hour already
-// means something went wrong. Web3Forms' free tier is 250 submissions a month —
-// a single unattended script would eat that in a minute.
+// means something went wrong. It also protects the sending quota: a single
+// unattended script would spend a day's allowance in a minute.
 const PER_IP_LIMIT = 3;
 const PER_IP_WINDOW = HOUR;
 
 /**
  * Per-field caps. Generous for a person, restrictive for a payload — the point
- * is that nothing unbounded reaches Web3Forms or the inbox behind it.
+ * is that nothing unbounded reaches the inbox.
  */
 const MAX_LENGTHS = {
   name: 100,
@@ -74,6 +94,60 @@ function validate(body: Record<string, unknown>): { values: Record<Field, string
   return { values };
 }
 
+/** Names what's missing so a misconfigured deploy says so instead of failing blind. */
+function missingConfig(): string[] {
+  const missing: string[] = [];
+  if (!API_KEY) missing.push("BREVO_API_KEY");
+  if (!SENDER_EMAIL) missing.push("CONTACT_SENDER_EMAIL");
+  if (!TO_EMAIL) missing.push("CONTACT_TO_EMAIL");
+  return missing;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * The mail body. Every value here was typed by an anonymous visitor, so all four
+ * are escaped — the inbox rendering this is a mail client, and an unescaped
+ * message field would let a submission put markup in it.
+ */
+function buildHtml(values: Record<Field, string>): string {
+  const row = (label: string, value: string) =>
+    `<tr><td style="padding:6px 14px 6px 0;vertical-align:top;color:#5b6b7c;white-space:nowrap">${label}</td>` +
+    `<td style="padding:6px 0;vertical-align:top;color:#1c2733">${escapeHtml(value)}</td></tr>`;
+
+  return [
+    '<div style="font-family:Tahoma,Arial,sans-serif;font-size:15px;line-height:1.7;color:#1c2733">',
+    '<table style="border-collapse:collapse;margin:0 0 16px">',
+    row("ชื่อ-นามสกุล", values.name),
+    row("ช่องทางติดต่อกลับ", values.contact),
+    row("เรื่อง", values.subject),
+    "</table>",
+    // white-space:pre-wrap so the line breaks the sender typed survive.
+    `<div style="white-space:pre-wrap;border-left:3px solid #dde3ea;padding-left:14px">${escapeHtml(values.message)}</div>`,
+    '<hr style="border:none;border-top:1px solid #dde3ea;margin:20px 0 12px">',
+    '<p style="color:#5b6b7c;font-size:13px;margin:0">ส่งจากฟอร์มติดต่อบนเว็บไซต์ ECTI</p>',
+    "</div>",
+  ].join("");
+}
+
+/**
+ * Reply-to, but only when the visitor gave something that is actually an email.
+ *
+ * The field asks for "ช่องทางการติดต่อกลับ (อีเมล หรืออื่นๆ)", so a phone number
+ * or a LINE id is a valid answer — and Brevo rejects the whole send if replyTo
+ * isn't a well-formed address. Skipping it there costs one convenience; sending
+ * it would cost the message.
+ */
+function replyTo(contact: string): { email: string } | undefined {
+  return EMAIL_RE.test(contact) ? { email: contact } : undefined;
+}
+
 export async function POST(request: Request) {
   if (!sameOrigin(request)) {
     return NextResponse.json({ error: "forbidden" }, { status: 403 });
@@ -110,37 +184,56 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "invalid_input", field: result.error }, { status: 400 });
   }
 
-  if (!ACCESS_KEY) {
-    console.error("contact: not configured — missing WEB3FORMS_ACCESS_KEY");
+  const missing = missingConfig();
+  if (missing.length > 0) {
+    console.error(`contact: not configured — missing ${missing.join(", ")}`);
     return NextResponse.json({ error: "server_error" }, { status: 500 });
   }
 
+  const { name, contact, subject } = result.values;
+
   let res: Response;
   try {
-    res = await fetch(WEB3FORMS_API, {
+    res = await fetch(BREVO_SEND_API, {
       method: "POST",
-      headers: { "content-type": "application/json", accept: "application/json" },
-      // Same field names the browser used to send, so the mail that lands in
-      // the inbox reads exactly as it did before.
-      body: JSON.stringify({ access_key: ACCESS_KEY, ...result.values }),
+      headers: {
+        "api-key": API_KEY as string,
+        "content-type": "application/json",
+        accept: "application/json",
+      },
+      body: JSON.stringify({
+        // Sender is our own verified address, never the visitor's: Brevo only
+        // sends as a sender it has verified, and putting a stranger's address
+        // here is how a domain's mail reputation gets spent.
+        sender: { name: SENDER_NAME, email: SENDER_EMAIL },
+        to: [{ email: TO_EMAIL }],
+        // The visitor's name in the subject, so the inbox is scannable without
+        // opening anything.
+        subject: `[ติดต่อจากเว็บ] ${subject} — ${name}`,
+        htmlContent: buildHtml(result.values),
+        replyTo: replyTo(contact),
+      }),
       cache: "no-store",
+      // Without this a hung connection holds the request open until the
+      // platform kills it, and the visitor watches a spinner the whole time.
+      signal: AbortSignal.timeout(10_000),
     });
   } catch (err) {
-    console.error("contact: cannot reach Web3Forms", err);
+    console.error("contact: cannot reach Brevo", err);
     return NextResponse.json({ error: "server_error" }, { status: 502 });
   }
 
-  // Web3Forms answers 200 with {success:false} for a rejected submission, so
-  // the status alone doesn't say whether the mail went out.
-  const data = await res.json().catch(() => null);
-
-  if (res.ok && data?.success) {
+  // 201 with a messageId on success.
+  if (res.ok) {
     return NextResponse.json({ ok: true }, { status: 201 });
   }
 
+  const data = await res.json().catch(() => null);
+
   console.error(
-    `contact: Web3Forms returned ${res.status}: ${JSON.stringify(data)}` +
-      (res.status === 401 || res.status === 403 ? " — check WEB3FORMS_ACCESS_KEY." : "")
+    `contact: Brevo returned ${res.status}: ${JSON.stringify(data)}` +
+      (res.status === 401 ? " — check BREVO_API_KEY." : "") +
+      (res.status === 400 ? " — CONTACT_SENDER_EMAIL must be a verified sender in Brevo." : "")
   );
   return NextResponse.json({ error: "server_error" }, { status: 502 });
 }


### PR DESCRIPTION
## สิ่งที่เปลี่ยน

`/api/contact` ส่งอีเมลผ่าน **Brevo** แทน Web3Forms

ส่วนที่เหลือของ route ไม่แตะเลย — origin check, honeypot, rate limit
ต่อ IP ที่นับก่อน validate, การจำกัดความยาวรายฟิลด์ ยังเหมือนเดิมทั้งหมด
เปลี่ยนแค่ปลายทางที่ส่งออก

## ทำไมต้องเปลี่ยน

ฟอร์มติดต่อบน production **ส่งไม่ได้เลยตั้งแต่ #103 ขึ้น** ตอบ 502 ทุกครั้ง

สาเหตุไม่ใช่บั๊กในโค้ดเรา แต่เป็นข้อจำกัดของแผน Web3Forms — ยิงคีย์ตรงจาก
server ได้ผลนี้:

```
HTTP 403
{"success":false,"message":"This method is not allowed. Use our API in
 client side or contact support with server IP address (Pro plan is required)"}
```

แผนฟรีรับเฉพาะการยิงจากเบราว์เซอร์ ซึ่งแปลว่า**จุดประสงค์ทั้งหมดของ #103 —
การมี endpoint ของเราเองไว้วาง rate limit — คือสิ่งที่แผนฟรีห้ามพอดี**
ไม่มีวิธีเขียนโค้ดแบบไหนที่ทำงานได้บนแผนนั้น

เลือก Brevo เพราะ transactional API ออกแบบมาให้เรียกจาก server อยู่แล้ว
เรามี account และ `BREVO_API_KEY` ตั้งใน Vercel อยู่แล้วจาก newsletter
และโควตาฟรี 300 ฉบับ/วัน มากกว่า Web3Forms 250 ฉบับ/เดือนอยู่มาก

`WEB3FORMS_ACCESS_KEY` ที่ตั้งไว้ไม่ได้ผิด — ไม่ต้องไปแก้ แค่ลบทิ้งได้เลย

Closes #105

## สามจุดที่อยากให้ดูตอนรีวิว

- **`replyTo` ใส่เฉพาะเมื่อ contact เป็นอีเมลจริง** ช่องนั้นถามว่า
  "ช่องทางการติดต่อกลับ (อีเมล หรืออื่นๆ)" เบอร์โทรหรือ LINE id เป็นคำตอบ
  ที่ถูกต้อง และ Brevo จะปฏิเสธทั้งฉบับถ้า `replyTo` ไม่ใช่อีเมลที่ถูกรูปแบบ
  ข้ามไปเสียความสะดวกไปหนึ่งอย่าง ใส่ไปเสียทั้งข้อความ
- **sender เป็นอีเมลของเราที่ verify แล้วเสมอ ไม่ใช่ของคนกรอก** Brevo ส่งได้
  เฉพาะ sender ที่ verify แล้ว และการเอาอีเมลคนอื่นไปใส่คือวิธีเผา
  reputation ของโดเมนตัวเอง
- **escape ทุก field** ค่าพวกนี้คนนอกพิมพ์มา และสิ่งที่ render มันคือ mail client

## ตรวจสอบยังไง

ทดสอบกับ endpoint จำลองที่ตอบแบบเดียวกับ Brevo เพื่อดัก payload จริงที่ส่งออก

- [x] `npx tsc --noEmit` ผ่าน
- [x] contact เป็นอีเมล → payload มี `replyTo` → 201
- [x] contact เป็นเบอร์โทร → payload **ไม่มี** `replyTo` → 201
- [x] `<script>alert(1)</script> & "..."` ในช่องข้อความ → ออกมาเป็น
      `&lt;script&gt;...&amp;...&quot;` ในอีเมล
- [x] ขึ้นบรรทัดใหม่ในข้อความยังอยู่ครบ (`white-space:pre-wrap`)
- [x] key ผิด → 502 พร้อม log `contact: Brevo returned 401: {...} — check BREVO_API_KEY.`
- [x] key ที่มี space หน้าหลัง → ยังใช้ได้ (`.trim()`)
- [ ] **ส่งฟอร์มจริงบน preview แล้วอีเมลเข้ากล่องสมาคม** ← ต้องทำหลังตั้ง env

## ⚠️ ผลกระทบ

- **Breaking change:** ไม่มี — แต่ฟอร์มพังอยู่ตอนนี้ PR นี้คือตัวแก้
- **ต้องตั้ง env ใหม่:** ✅ **มี — ต้องตั้งก่อน merge ไม่งั้นจะได้ 500 แทน 502**

  | ตัวแปร | ค่า | environment |
  |---|---|---|
  | `CONTACT_SENDER_EMAIL` | อีเมลผู้ส่งที่ **verify ใน Brevo แล้ว** (ตัวเดียวกับที่ newsletter ใช้ได้) | ทุก env |
  | `CONTACT_TO_EMAIL` | อีเมลปลายทางของสมาคม | ทุก env |
  | `CONTACT_SENDER_NAME` | ไม่บังคับ default `"ECTI Website"` | — |

  `BREVO_API_KEY` มีอยู่แล้ว ไม่ต้องทำอะไร
  อย่าลืมติ๊ก **Preview** ด้วย ไม่ใช่แค่ Production

- **ลบได้หลัง merge:** `WEB3FORMS_ACCESS_KEY` ใน Vercel และคีย์ที่ Web3Forms
  (คีย์ตัวนั้นเคยอยู่ใน bundle สาธารณะมาก่อน ถือว่าหลุดแล้ว — ลบทิ้งดีกว่าเก็บ)
- **ต้องแก้ข้อมูลใน Strapi:** ไม่มี
- **ต้อง deploy พร้อมกันกับอีก repo:** ไม่

## หมายเหตุสำหรับ #104

PR นี้แตะ `app/api/contact/route.ts` คนละส่วนกับ #104 (ตรงนั้นแก้วิธีอ่าน
body) merge เรียงกันได้ ไม่ควรชน และ `.env.example` ที่ #104 เพิ่มเข้ามา
จะอัปเดตให้มีสามตัวแปรข้างบนด้วย

## Checklist

- [x] commit message เป็นรูปแบบ `<type>(<scope>): <description>`
- [ ] ทดสอบทั้ง locale `th` และ `en`
- [x] ไม่มี secret หรือ key หลุดเข้า commit
