### PR TITLE
fix(events): drop empty locations before they reach the filter

### DIFF
--- a/app/[locale]/(site)/events/[slug]/page.tsx
+++ b/app/[locale]/(site)/events/[slug]/page.tsx
@@ -173,10 +173,12 @@ export default async function EventDetailPage({ params }: PageProps) {
                     <CalendarDays className="h-4 w-4 text-primary" />
                     {date}
                   </span>
-                  <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
-                    <MapPin className="h-4 w-4 text-primary" />
-                    {location}
-                  </span>
+                  {location ? (
+                    <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                      <MapPin className="h-4 w-4 text-primary" />
+                      {location}
+                    </span>
+                  ) : null}
                 </div>
                 <p className="text-sm leading-relaxed text-muted-foreground">
                   {overview}
@@ -288,20 +290,25 @@ export default async function EventDetailPage({ params }: PageProps) {
               </Card>
             )}
 
-            {/* Venue */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-lg">
-                  <MapPin className="h-5 w-5 text-primary" />
-                  {dict.events.detailVenue}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-sm leading-relaxed text-muted-foreground">
-                  {location}
-                </p>
-              </CardContent>
-            </Card>
+            {/* Venue — omitted when unknown. An empty card under a "Venue"
+                heading reads as missing data on our side; leaving it out says
+                the same thing more quietly, and the 41 imported conferences
+                have no venue recorded anywhere. */}
+            {location ? (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-lg">
+                    <MapPin className="h-5 w-5 text-primary" />
+                    {dict.events.detailVenue}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm leading-relaxed text-muted-foreground">
+                    {location}
+                  </p>
+                </CardContent>
+              </Card>
+            ) : null}
 
             {/* Organizer */}
             <Card>

--- a/app/[locale]/(site)/events/page.tsx
+++ b/app/[locale]/(site)/events/page.tsx
@@ -48,9 +48,15 @@ export default async function EventsPage({ params }: PageProps) {
 
   const years = [...new Set(events.map(e => String(e.year)))].sort((a, b) => Number(b) - Number(a));
 
-  const locations = [
-    ...new Set(events.map(e => e.location)),
-  ];
+  // Empty entries are filtered out because Radix throws on a SelectItem whose
+  // value is an empty string — it reserves "" for "nothing selected". The
+  // legacy conference import is where they come from: the old site never
+  // recorded a venue for any of its 41 conferences, so every one of them
+  // arrives with location unset, and one of those was enough to take the whole
+  // page down rather than just leave a filter option blank.
+  const locations = [...new Set(events.map((e) => e.location))]
+    .filter((location) => location.trim() !== "")
+    .sort((a, b) => a.localeCompare(b));
 
   return (
     <>

--- a/components/events-list-client.tsx
+++ b/components/events-list-client.tsx
@@ -427,10 +427,12 @@ function EventCard({
             <CalendarDays className="h-4 w-4 shrink-0 text-primary" />
             {date}
           </span>
-          <span className="flex items-center gap-1.5">
-            <MapPin className="h-4 w-4 shrink-0 text-primary" />
-            {location}
-          </span>
+          {location ? (
+            <span className="flex items-center gap-1.5">
+              <MapPin className="h-4 w-4 shrink-0 text-primary" />
+              {location}
+            </span>
+          ) : null}
         </div>
 
         {/* Deadlines row */}


### PR DESCRIPTION
## อาการ

เปิดตัวกรอง "สถานที่" บนหน้า `/events` แล้วหน้าพัง

```
A <Select.Item /> must have a value prop that is not an empty string.
```

## สาเหตุ

งานประชุม 41 งานที่เพิ่ง import เข้ามา**ไม่มีสถานที่สักงาน** — เว็บเก่าไม่เคยบันทึกไว้ `events-data.ts` แปลงเป็น `""` แล้วหน้า events ส่งเข้า `<SelectItem value="">` ตรงๆ

Radix สงวน `""` ไว้แปลว่า "ยังไม่ได้เลือก" เลยโยน error ทิ้ง — **ค่าว่างค่าเดียวก็พอทำให้ทั้งหน้าล่ม** แทนที่จะแค่มีตัวเลือกเปล่าๆ อันนึง

**ทำไม build ผ่าน:** Radix ไม่ mount `SelectContent` จนกว่าจะเปิดเมนู ตอน prerender จึงไม่มีอะไร render รายการพวกนั้นเลย error รอคนคลิกครั้งแรก

## สิ่งที่เปลี่ยน

- กรองค่าว่างออกก่อนส่งเข้า Select แล้วเรียงลำดับ
- ซ่อนหมุดสถานที่บนการ์ด เมื่อไม่มีข้อมูล (เดิมวาดหมุดค้างไว้เฉยๆ ไม่มีข้อความตาม)
- ซ่อนการ์ด "สถานที่จัดงาน" บนหน้ารายละเอียด เมื่อว่าง — การ์ดเปล่าใต้หัวข้ออ่านแล้วเหมือนข้อมูลหาย ไม่ใส่เลยสื่อสารเรื่องเดียวกันแบบเงียบกว่า

## ตรวจสอบยังไง

- [x] `npx tsc --noEmit` ผ่าน
- [x] build กับ stub ที่เสิร์ฟงาน 41 งานแบบไม่มีสถานที่ **บวกงานที่มีสถานที่ 1 งาน** → ตัวกรองเสนอเฉพาะสถานที่จริง และมีการ์ดเดียวที่วาดหมุด
- [x] ตรวจหน้าที่ build ออกมา ไม่มี `Invalid Date` / `undefined` / `null` หลุด

## ผลกระทบ

- **Breaking change:** ไม่มี
- **ต้องตั้ง env ใหม่:** ไม่มี
- **ต้องแก้ข้อมูลใน Strapi:** ไม่ต้อง — แต่ถ้าอยากให้มีตัวกรองสถานที่ ต้องไปเติม `location` ให้งานเก่าเอง ซึ่งเว็บเก่าไม่มีข้อมูลให้
- **ต้อง deploy พร้อมกันกับอีก repo:** ไม่

## Checklist

- [x] commit message เป็นรูปแบบ `<type>(<scope>): <description>`
- [x] ทดสอบทั้ง locale `th` และ `en`
- [x] ไม่มี secret หรือ key หลุดเข้า commit