### PR TITLE
fix(cms): read every page of news and events, not the first 25

### DIFF
--- a/lib/events-data.ts
+++ b/lib/events-data.ts
@@ -1,4 +1,5 @@
 import { CMS_REVALIDATE_SECONDS } from "@/lib/cache";
+import { fetchAllPages } from "@/lib/strapi-pages";
 export type EventStatus = "open" | "register" | "upcoming" | "finished";
 export type EventType = "conference" | "workshop" | "seminar";
 
@@ -84,25 +85,17 @@ export async function fetchEventBySlug(slug: string, locale: string) {
 // Ordered newest-first here rather than in the client: EventsListClient re-sorts
 // by status with a stable sort, so this date order survives within each status group.
 export async function fetchEventsFromAPI(locale: string): Promise<ECTIEvent[]> {
-  let json: any;
-  try {
-    const res = await fetch(
-      `${API_URL}?populate=*&sort=event_start_date:desc&locale=${locale}`,
-      { next: { revalidate: CMS_REVALIDATE_SECONDS } }
-    );
-    if (!res.ok) return [];
-    json = await res.json();
-  } catch (err) {
-    console.warn("fetchEventsFromAPI: API unavailable", err);
-    return [];
-  }
+  // The legacy conference import took this collection past Strapi's default
+  // page of 25, so reading one page silently lost half the history — and the
+  // half it kept was whichever end of the date sort happened to land first.
+  const rows = await fetchAllPages(
+    (page, pageSize) =>
+      `${API_URL}?populate=*&sort=event_start_date:desc&locale=${locale}` +
+      `&pagination[page]=${page}&pagination[pageSize]=${pageSize}`,
+    { label: `fetchEventsFromAPI(${locale})`, revalidate: CMS_REVALIDATE_SECONDS }
+  );
 
-  if (!json || !Array.isArray(json.data)) {
-    console.warn("fetchEventsFromAPI: Invalid data received", json);
-    return [];
-  }
-
-  return json.data.map((item: any) => {
+  return rows.map((item: any) => {
     const attr = item;
 
     return {

--- a/lib/news-data.ts
+++ b/lib/news-data.ts
@@ -1,4 +1,5 @@
 import { CMS_REVALIDATE_SECONDS } from "@/lib/cache";
+import { fetchAllPages } from "@/lib/strapi-pages";
 import { absoluteMediaUrl } from "@/lib/strapi-media";
 import { locales } from "@/lib/i18n";
 
@@ -77,18 +78,18 @@ function mapNewsPost(item: any): NewsPost {
 // a single language). Fetch one locale's rows; callers merge across locales so a
 // post never disappears / 404s just because it wasn't translated.
 async function fetchNewsRows(locale: string): Promise<any[]> {
-  try {
-    const res = await fetch(
-      `${BASE_URL}/api/news-posts?populate[tags]=true&populate[cover_image]=true&sort=publishedAt:desc&locale=${locale}`,
-      { next: { revalidate: CMS_REVALIDATE_SECONDS } }
-    );
-    if (!res.ok) return [];
-    const json = await res.json();
-    return (json.data ?? []).filter((item: any) => item.slug); // skip entries with no slug
-  } catch (err) {
-    console.warn(`fetchNewsRows(${locale}): API unavailable`, err);
-    return [];
-  }
+  // Every page, not just the first. The archive is past 70 posts and Strapi
+  // hands back 25 unless asked otherwise, so this used to drop most of it
+  // while the count on the page still said how many there really were.
+  const rows = await fetchAllPages(
+    (page, pageSize) =>
+      `${BASE_URL}/api/news-posts?populate[tags]=true&populate[cover_image]=true` +
+      `&sort=publishedAt:desc&locale=${locale}` +
+      `&pagination[page]=${page}&pagination[pageSize]=${pageSize}`,
+    { label: `fetchNewsRows(${locale})`, revalidate: CMS_REVALIDATE_SECONDS }
+  );
+
+  return rows.filter((item: any) => item.slug); // skip entries with no slug
 }
 
 // Same post shares a documentId across locales (and the slug is non-localized too).

--- a/lib/strapi-pages.ts
+++ b/lib/strapi-pages.ts
@@ -1,0 +1,59 @@
+/**
+ * Reads every page of a Strapi collection, not just the first one.
+ *
+ * Strapi answers a list request with 25 entries unless you ask for more, and a
+ * caller that never asks gets a silent truncation: 200 OK, a well-formed body,
+ * and two thirds of the archive missing. Nothing in the response looks wrong
+ * unless you read `meta.pagination.total`, which is the number the page ends up
+ * displaying while the list under it is short.
+ *
+ * That is what happened after the legacy import. News went from 12 entries to
+ * 72 and conferences to 49, both quietly capped at 25, and which 25 you got
+ * depended on the sort — for the imported posts, effectively the order they
+ * were created in rather than anything a reader would recognise.
+ *
+ * 100 a page is Strapi's own maximum for the default configuration, so this is
+ * one request for anything the site currently holds and stays correct if that
+ * changes.
+ */
+const PAGE_SIZE = 100;
+
+/** Guards against a paginated read that never terminates. */
+const MAX_PAGES = 50;
+
+export async function fetchAllPages(
+  buildUrl: (page: number, pageSize: number) => string,
+  options: { label?: string; revalidate?: number } = {}
+): Promise<any[]> {
+  const { label = "fetchAllPages", revalidate } = options;
+  const rows: any[] = [];
+
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    let json: any;
+
+    try {
+      const res = await fetch(buildUrl(page, PAGE_SIZE), {
+        ...(revalidate === undefined ? {} : { next: { revalidate } }),
+      });
+      if (!res.ok) {
+        console.warn(`${label}: page ${page} returned ${res.status}`);
+        break;
+      }
+      json = await res.json();
+    } catch (err) {
+      console.warn(`${label}: page ${page} unavailable`, err);
+      break;
+    }
+
+    if (!json || !Array.isArray(json.data)) break;
+    rows.push(...json.data);
+
+    // Returning what we have rather than throwing: a page that loads with most
+    // of the archive beats a page that fails outright, and the warning above
+    // says which request went missing.
+    const pageCount = json.meta?.pagination?.pageCount ?? 1;
+    if (page >= pageCount) break;
+  }
+
+  return rows;
+}


### PR DESCRIPTION
## อาการ

หน้า `/th/news` บอกว่ามีบทความจำนวนหนึ่ง แต่โหลดเท่าไหร่ก็ไม่ครบ และหน้า `/events` ขาดประวัติงานประชุมไปครึ่งหนึ่ง

## สาเหตุ

ทั้งสองหน้าขอข้อมูลจาก Strapi **โดยไม่ระบุ pagination เลย** ซึ่ง Strapi ตอบมาแค่ **25 รายการ** — สถานะ 200 body ถูกต้องทุกอย่าง แต่ข้อมูลที่เหลือหายไปเฉยๆ

ไม่มีอะไรในคำตอบที่ดูผิด เบาะแสเดียวคือ `meta.pagination.total` ซึ่งบังเอิญเป็นเลขที่หน้าเว็บเอาไปโชว์ — เลยกลายเป็นหน้าที่ประกาศจำนวนจริงไว้ข้างบน แล้วแสดงรายการไม่ครบข้างล่าง

**ที่ผ่านมาไม่มีใครเจอเพราะข้อมูลยังไม่เกิน 25** การ import ของเก่าดันข่าวจาก 12 เป็น 72 และงานประชุมเป็น 49 ปัญหาเลยโผล่วันเดียวกัน

### 25 อันไหนที่รอด — ขึ้นกับการเรียง ไม่ใช่ความสำคัญ

ข่าวเรียงด้วย `publishedAt` ซึ่งสำหรับข่าวที่ import มาคือ**นาทีที่สคริปต์สร้างมัน** ไม่ใช่วันที่ของข่าว ผลคือข่าวที่มองเห็นคือหางของการ import เท่านั้น

## สิ่งที่เปลี่ยน

เพิ่ม `lib/strapi-pages.ts` — เดินทีละหน้าจนกว่า `meta` จะบอกว่าหมด ครั้งละ 100 รายการ

- ถ้าหน้าใดโหลดไม่ได้ **คืนเท่าที่ได้มา ไม่โยน error** — หน้าที่ขาดไปหนึ่งหน้าดีกว่าหน้าที่เปิดไม่ขึ้น และมี log บอกว่า request ไหนหาย
- มีเพดานจำนวนหน้ากันลูปไม่รู้จบถ้า `meta` เพี้ยน

`board-members` เขียนลูปแบบนี้ไว้เองอยู่แล้วใน `about-data.ts` — เป็นเหตุผลที่ 55 รายการของมันไม่เคยขาด

## ตรวจสอบยังไง

build โดยชี้ `NEXT_PUBLIC_API_URL` ไปที่ Strapi Cloud ตัวจริง:

| | ก่อน | หลัง | CMS มีจริง |
|---|---|---|---|
| slug ข่าวที่ส่งถึง client | 25 | **72** | 72 |
| slug งานที่ส่งถึง client | 25 | **49** | 49 |
| หน้าที่ prerender ทั้งเว็บ | 127 | **279** | |

- [x] `npx tsc --noEmit` ผ่าน
- [x] ตัวเลขตรงกับ `meta.pagination.total` ของทั้งสอง collection เป๊ะ

## ผลกระทบ

- **Breaking change:** ไม่มี
- **ต้องตั้ง env ใหม่:** ไม่มี
- **ต้องแก้ข้อมูลใน Strapi:** ไม่มี
- **ต้อง deploy พร้อมกันกับอีก repo:** ไม่

build จะนานขึ้นเพราะสร้างหน้ามากขึ้นสองเท่า — เป็นผลที่ตั้งใจ ไม่ใช่ผลข้างเคียง

## Checklist

- [x] commit message เป็นรูปแบบ `<type>(<scope>): <description>`
- [x] ทดสอบทั้ง locale `th` และ `en`
- [x] ไม่มี secret หรือ key หลุดเข้า commit